### PR TITLE
网易云扫码登录/解析优化[beta]

### DIFF
--- a/apps/tools.js
+++ b/apps/tools.js
@@ -1644,8 +1644,6 @@ async neteaseStatus(e, reck) {
             }
 
             let url = await resp.data.data?.[0]?.url || null;
-            // logger.info('获取信息url', resp.data.data?.[0]?.url);
-            // logger.info('获取信息', resp.data.data?.[0]);
             const AudioLevel = translateToChinese(resp.data.data?.[0]?.level)
             const AudioSize = bytesToMB(resp.data.data?.[0]?.size)
             // 获取歌曲信息
@@ -1659,11 +1657,11 @@ async neteaseStatus(e, reck) {
                 const song = res.data.songs[0];
                 return song?.al?.picUrl
             });
-            // 一般这个情况是VIP歌曲 (如果没有url或者是国内, 国内全走临时接口，后续如果不要删除逻辑'!isOversea ||')
+            // 一般这个情况是VIP歌曲 (如果没有url或者是国内,没有ck的走临时接口)
             if (!isCkExpired || url == null) {
                 url = await this.musicTempApi(e, title, "网易云音乐");
             } else {
-                // 不是VIP歌曲，直接识别完就下一步
+                // 拥有ck，并且有效，直接进行解析
                 e.reply([segment.image(coverUrl), `${this.identifyPrefix}识别：网易云音乐，${title}\n当前下载音质: ${AudioLevel}\n预估大小: ${AudioSize}MB`]);
             }
             // 动态判断后缀名

--- a/apps/tools.js
+++ b/apps/tools.js
@@ -221,7 +221,7 @@ export class tools extends plugin {
                     permission: 'master',
                 },
                 {
-                    reg: "^#(网易云扫码登录|网易扫码登录)$",
+                    reg: "^#(网易云扫码登录|网易扫码登录|网易登录|网易云登录)$",
                     fnc: 'netease_scan',
                     permission: 'master',
                 },

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -22,6 +22,11 @@ biliCDN: 0 # 哔哩哔哩 CDN，默认为0表示不使用
 biliDownloadMethod: 0 # 哔哩哔哩的下载方式：0默认使用原生稳定的下载方式，如果你在乎内存可以使用轻量的wget和axel下载方式，如果在乎性能可以使用Aria2下载
 biliResolution: 1 # 哔哩哔哩的下载画质，0为原画，1为清晰画，2为流畅画（默认为0）
 
+useLocalNeteaseAPI: false #是否使用网易云解析自建API
+neteaseCookie: '' #网易云ck
+neteaseCloudAPIServer: '' #网易云自建服务器地址
+neteaseCloudAudioQuality: exhigh #网易云解析最高音质 默认exhigh(极高) 分类：standard => 标准,higher => 较高, exhigh=>极高, lossless=>无损, hires=>Hi-Res, jyeffect => 高清环绕声, sky => 沉浸环绕声, dolby => 杜比全景声, jymaster => 超清母带
+
 YouTubeGraphicsOptions: 720 #YouTobe的下载画质，0为原画，1080，720，480，自定义画面高度（默认为720）
 
 douyinCookie: '' # douyin's cookie, 格式：odin_tt=xxx;passport_fe_beating_status=xxx;sid_guard=xxx;uid_tt=xxx;uid_tt_ss=xxx;sid_tt=xxx;sessionid=xxx;sessionid_ss=xxx;sid_ucp_v1=xxx;ssid_ucp_v1=xxx;passport_assist_user=xxx;ttwid=xxx;

--- a/constants/constant.js
+++ b/constants/constant.js
@@ -193,6 +193,18 @@ export const YOUTUBE_GRAPHICS_LIST = Object.freeze([
     { label: '720P 高清', value: 720 },
     { label: '480P 清晰', value: 480 },
 ]);
+
+export const NETEASECLOUD_QUALITY_LIST = Object.freeze([
+    { label: '标准', value: 'standard' },
+    { label: '较高', value: 'higher' },
+    { label: '极高', value: 'exhigh' },
+    { label: '无损', value: 'lossless' },
+    { label: 'Hi-Res', value: 'hires' },
+    { label: '高清环绕声', value: 'jyeffect' },
+    { label: '沉浸环绕声', value: 'sky' },
+    { label: '杜比全景声', value: 'dolby' },
+    { label: '超清母带', value: 'jymaster' },
+]);
 /**
  * 消息撤回时间
  * @type {number}

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import path from "path";
-import { BILI_CDN_SELECT_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, YOUTUBE_GRAPHICS_LIST } from "./constants/constant.js";
+import { BILI_CDN_SELECT_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST } from "./constants/constant.js";
 import model from "./model/config.js";
 
 const pluginName = `rconsole-plugin`;
@@ -228,6 +228,46 @@ export function supportGuoba() {
                     component: "Select",
                     componentProps: {
                         options: YOUTUBE_GRAPHICS_LIST,
+                    }
+                },
+                {
+                    field: "tools.useLocalNeteaseAPI",
+                    label: "使用自建网易云API",
+                    bottomHelpMessage:
+                        "默认不开启，有条件可以查看https://gitlab.com/Binaryify/neteasecloudmusicapi进行搭建",
+                    component: "Switch",
+                    required: false,
+                },
+                {
+                    field: "tools.neteaseCloudAPIServer",
+                    label: "自建网易云API地址",
+                    bottomHelpMessage:
+                        "填入自建API地址，例：http://xxxxxxxx",
+                    component: "Input",
+                    required: false,
+                    componentProps: {
+                        placeholder: "填入自建API地址",
+                    },
+                },
+                {
+                    field: "tools.neteaseCookie",
+                    label: "网易云Cookie",
+                    bottomHelpMessage:
+                        "可以发送 #网易云扫码登陆 快捷获取 或 者在网易云官网自己获取",
+                    component: "Input",
+                    required: false,
+                    componentProps: {
+                        placeholder: "使用vip账号登陆获取更高音质解析",
+                    },
+                },
+                {
+                    field: "tools.neteaseCloudAudioQuality",
+                    label: "网易云解析最高音质",
+                    bottomHelpMessage:
+                        "网易云解析最高音质(需vip账号ck！！！ 默认极高，更高请根据登陆的账号和服务器承载能力进行选择)",
+                    component: "Select",
+                    componentProps: {
+                        options: NETEASECLOUD_QUALITY_LIST,
                     }
                 },
                 {


### PR DESCRIPTION
✨ 新增  网易云扫码登录方法，自动存储ck，ck可在锅巴进行修改
✨ 新增  网易云开启自建服务器选项，可在锅巴进行开启使用自建网易云API进行解析
✨ 新增  网易云登录状态查询，当你怀疑ck过期或者想看看自己vip什么时候到期？可以触发试试
✨ 新增  网易云解析音质选项，可在锅巴进行更改
🎈 优化  网易云解析逻辑