### PR TITLE
修复iesdouyin.com无法解析的问题

### DIFF
--- a/apps/tools.js
+++ b/apps/tools.js
@@ -169,7 +169,7 @@ export class tools extends plugin {
                     fnc: "trans",
                 },
                 {
-                    reg: "((v|live).douyin.com|webcast.amemv.com|www.douyin.com/(video|note|live|share|jingxuan|discover))",
+                    reg: "((v|live).douyin.com|webcast.amemv.com|iesdouyin.com|www.douyin.com/(video|note|live|share|jingxuan|discover))",
                     fnc: "douyin",
                 },
                 {
@@ -430,7 +430,7 @@ export class tools extends plugin {
             logger.info(`[R插件][全局解析控制] ${RESOLVE_CONTROLLER_NAME_ENUM.douyin} 已拦截`);
             return false;
         }
-        const urlRex = /(http:\/\/|https:\/\/)((v|live).douyin.com\/[A-Za-z\d._?%&+\-=\/#]*|webcast.amemv.com\/[A-Za-z\d._?%&+\-=\/#]*|www.douyin.com\/((video|note|live)\/[0-9]+|share\/slides\/[0-9]+|(jingxuan|discover)\?[A-Za-z\d._?%&+\-=\/#]*modal_id=[0-9]+[A-Za-z\d._?%&+\-=\/#]*))/;
+        const urlRex = /(http:\/\/|https:\/\/)((v|live).douyin.com\/[A-Za-z\d._?%&+\-=\/#]*|webcast.amemv.com\/[A-Za-z\d._?%&+\-=\/#]*|(www\.)?iesdouyin.com\/[A-Za-z\d._?%&+\-=\/#]*|www.douyin.com\/((video|note|live)\/[0-9]+|share\/slides\/[0-9]+|(jingxuan|discover)\?[A-Za-z\d._?%&+\-=\/#]*modal_id=[0-9]+[A-Za-z\d._?%&+\-=\/#]*))/;
         // 检测无效链接，例如：v.douyin.com，静默忽略
         if (!urlRex.test(e.msg)) {
             return false;


### PR DESCRIPTION
新增偶现分享时未自动转换短链无法触发，需要确保正则只精确匹配并截取合法的 URL 部分。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Douyin link support to recognize additional URL formats, including `iesdouyin.com` links, enabling broader compatibility with the Douyin parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->