### PR TITLE
feat(微信文章): 新增元宝解析模式，复用视频号 Cookie 抓取并总结文章

### DIFF
--- a/apps/switchers.js
+++ b/apps/switchers.js
@@ -50,6 +50,11 @@ export class switchers extends plugin {
                     reg: "^#设置视频号[Cc]ookie\\s*(.*)$",
                     fnc: "setWeixinChannelCookie",
                     permission: "master",
+                },
+                {
+                    reg: "^#微信文章解析模式\\s*(通用|元宝)?$",
+                    fnc: "setWeixinArticleResolveMode",
+                    permission: "master",
                 }
             ]
         });
@@ -117,6 +122,77 @@ export class switchers extends plugin {
         } catch (err) {
             logger.error(`[R插件][视频号] 设置 Cookie 失败: ${err.message}`);
             e.reply(`设置视频号 Cookie 失败: ${err.message}`);
+            return false;
+        }
+    }
+
+    /**
+     * 切换微信文章（mp.weixin.qq.com）解析模式
+     *   - 通用模式 general：浏览器抓取页面正文 + 自配 AI（kimi/openai）总结（默认，现有逻辑）
+     *   - 元宝模式 yuanbao：直接把链接发给腾讯元宝让其抓取并总结，与视频号共用元宝 Cookie
+     *     优点：规避微信页面风控（"环境异常"），元宝服务器抓取不走用户服务器 IP
+     *     注意：元宝对话接口有 IP 风控，部署服务器 IP 需与元宝登录 IP 一致，否则会 401
+     *
+     * 用法：
+     *   1. `#微信文章解析模式`（不带参数）→ 查看当前模式
+     *   2. `#微信文章解析模式 通用` → 切换到通用模式
+     *   3. `#微信文章解析模式 元宝` → 切换到元宝模式
+     * @param e
+     * @returns {Promise<boolean>}
+     */
+    async setWeixinArticleResolveMode(e) {
+        try {
+            const arg = (e.msg.replace(/^#微信文章解析模式\s*/i, '').trim() || '').toLowerCase();
+            const current = config.getConfig("tools").weixinArticleResolveMode || 'general';
+
+            // 无参数：查看当前状态
+            if (!arg) {
+                const modeText = current === 'yuanbao' ? '元宝模式（走腾讯元宝抓取+总结）' : '通用模式（浏览器抓取+自配AI总结）';
+                e.reply(
+                    `微信文章解析模式\n` +
+                    `当前模式：${modeText}\n\n` +
+                    `可选模式：\n` +
+                    `• 通用：浏览器抓取页面正文 + 自配 AI（kimi/openai）总结（默认）\n` +
+                    `• 元宝：直接把链接发给腾讯元宝抓取总结，与视频号共用元宝 Cookie，规避微信页面风控\n\n` +
+                    `切换命令：\n` +
+                    `#微信文章解析模式 通用\n` +
+                    `#微信文章解析模式 元宝\n\n` +
+                    `注意：元宝模式依赖元宝 Cookie，请先通过 #设置视频号Cookie 配置；且元宝对话接口有 IP 风控，部署服务器 IP 需与元宝登录 IP 一致`
+                );
+                return true;
+            }
+
+            // 参数校验
+            if (arg !== 'general' && arg !== 'yuanbao' && arg !== '通用' && arg !== '元宝') {
+                e.reply('⚠️ 参数错误，仅支持「通用」或「元宝」');
+                return true;
+            }
+
+            // 统一映射到英文枚举值
+            const newMode = (arg === 'yuanbao' || arg === '元宝') ? 'yuanbao' : 'general';
+
+            // 切到元宝模式时校验 Cookie 是否已配置（友好提示，但不阻止切换）
+            if (newMode === 'yuanbao') {
+                const cookie = config.getConfig("tools").weixinChannelYuanbaoCookie;
+                if (!cookie) {
+                    e.reply(
+                        `⚠️ 已切换到元宝模式，但尚未配置腾讯元宝 Cookie\n` +
+                        `请私聊发送 #设置视频号Cookie 进行设置\n` +
+                        `（元宝 Cookie 同时用于视频号解析与微信文章元宝模式）`
+                    );
+                    config.updateField("tools", "weixinArticleResolveMode", newMode);
+                    return true;
+                }
+            }
+
+            config.updateField("tools", "weixinArticleResolveMode", newMode);
+            const modeText = newMode === 'yuanbao' ? '元宝模式' : '通用模式';
+            logger.mark(`[R插件][微信文章] 管理员 ${e.user_id} 切换解析模式为 ${modeText}`);
+            e.reply(`✅ 微信文章解析模式已切换为：${modeText}\n⚠️ 需重启插件后生效`);
+            return true;
+        } catch (err) {
+            logger.error(`[R插件][微信文章] 切换解析模式失败: ${err.message}`);
+            e.reply(`切换解析模式失败: ${err.message}`);
             return false;
         }
     }

--- a/apps/switchers.js
+++ b/apps/switchers.js
@@ -50,11 +50,6 @@ export class switchers extends plugin {
                     reg: "^#设置视频号[Cc]ookie\\s*(.*)$",
                     fnc: "setWeixinChannelCookie",
                     permission: "master",
-                },
-                {
-                    reg: "^#微信文章解析模式\\s*(通用|元宝)?$",
-                    fnc: "setWeixinArticleResolveMode",
-                    permission: "master",
                 }
             ]
         });
@@ -122,77 +117,6 @@ export class switchers extends plugin {
         } catch (err) {
             logger.error(`[R插件][视频号] 设置 Cookie 失败: ${err.message}`);
             e.reply(`设置视频号 Cookie 失败: ${err.message}`);
-            return false;
-        }
-    }
-
-    /**
-     * 切换微信文章（mp.weixin.qq.com）解析模式
-     *   - 通用模式 general：浏览器抓取页面正文 + 自配 AI（kimi/openai）总结（默认，现有逻辑）
-     *   - 元宝模式 yuanbao：直接把链接发给腾讯元宝让其抓取并总结，与视频号共用元宝 Cookie
-     *     优点：规避微信页面风控（"环境异常"），元宝服务器抓取不走用户服务器 IP
-     *     注意：元宝对话接口有 IP 风控，部署服务器 IP 需与元宝登录 IP 一致，否则会 401
-     *
-     * 用法：
-     *   1. `#微信文章解析模式`（不带参数）→ 查看当前模式
-     *   2. `#微信文章解析模式 通用` → 切换到通用模式
-     *   3. `#微信文章解析模式 元宝` → 切换到元宝模式
-     * @param e
-     * @returns {Promise<boolean>}
-     */
-    async setWeixinArticleResolveMode(e) {
-        try {
-            const arg = (e.msg.replace(/^#微信文章解析模式\s*/i, '').trim() || '').toLowerCase();
-            const current = config.getConfig("tools").weixinArticleResolveMode || 'general';
-
-            // 无参数：查看当前状态
-            if (!arg) {
-                const modeText = current === 'yuanbao' ? '元宝模式（走腾讯元宝抓取+总结）' : '通用模式（浏览器抓取+自配AI总结）';
-                e.reply(
-                    `微信文章解析模式\n` +
-                    `当前模式：${modeText}\n\n` +
-                    `可选模式：\n` +
-                    `• 通用：浏览器抓取页面正文 + 自配 AI（kimi/openai）总结（默认）\n` +
-                    `• 元宝：直接把链接发给腾讯元宝抓取总结，与视频号共用元宝 Cookie，规避微信页面风控\n\n` +
-                    `切换命令：\n` +
-                    `#微信文章解析模式 通用\n` +
-                    `#微信文章解析模式 元宝\n\n` +
-                    `注意：元宝模式依赖元宝 Cookie，请先通过 #设置视频号Cookie 配置；且元宝对话接口有 IP 风控，部署服务器 IP 需与元宝登录 IP 一致`
-                );
-                return true;
-            }
-
-            // 参数校验
-            if (arg !== 'general' && arg !== 'yuanbao' && arg !== '通用' && arg !== '元宝') {
-                e.reply('⚠️ 参数错误，仅支持「通用」或「元宝」');
-                return true;
-            }
-
-            // 统一映射到英文枚举值
-            const newMode = (arg === 'yuanbao' || arg === '元宝') ? 'yuanbao' : 'general';
-
-            // 切到元宝模式时校验 Cookie 是否已配置（友好提示，但不阻止切换）
-            if (newMode === 'yuanbao') {
-                const cookie = config.getConfig("tools").weixinChannelYuanbaoCookie;
-                if (!cookie) {
-                    e.reply(
-                        `⚠️ 已切换到元宝模式，但尚未配置腾讯元宝 Cookie\n` +
-                        `请私聊发送 #设置视频号Cookie 进行设置\n` +
-                        `（元宝 Cookie 同时用于视频号解析与微信文章元宝模式）`
-                    );
-                    config.updateField("tools", "weixinArticleResolveMode", newMode);
-                    return true;
-                }
-            }
-
-            config.updateField("tools", "weixinArticleResolveMode", newMode);
-            const modeText = newMode === 'yuanbao' ? '元宝模式' : '通用模式';
-            logger.mark(`[R插件][微信文章] 管理员 ${e.user_id} 切换解析模式为 ${modeText}`);
-            e.reply(`✅ 微信文章解析模式已切换为：${modeText}\n⚠️ 需重启插件后生效`);
-            return true;
-        } catch (err) {
-            logger.error(`[R插件][微信文章] 切换解析模式失败: ${err.message}`);
-            e.reply(`切换解析模式失败: ${err.message}`);
             return false;
         }
     }

--- a/apps/tools.js
+++ b/apps/tools.js
@@ -3941,6 +3941,13 @@ export class tools extends plugin {
         // 校验 Cookie
         const cookie = this.weixinChannelYuanbaoCookie;
         if (!cookie) {
+            // 未配元宝 Cookie：若已配自配 AI，自动回退通用模式（与调用失败回退策略一致）
+            if (!_.isEmpty(this.aiApiKey)) {
+                e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）未配置腾讯元宝 Cookie，正在自动回退到通用模式（${this.aiModel}）...`, true);
+                logger.mark(`[R插件][微信文章] 未配元宝 Cookie，回退到通用模式`);
+                return await this._weixinArticleGeneral(e, articleUrl, name);
+            }
+            // 既没元宝 Cookie 也没自配 AI，只能提示用户
             e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）\n⚠️ 未配置腾讯元宝 Cookie，请联系管理员私聊发送 #设置视频号Cookie 进行设置`);
             return true;
         }
@@ -4022,33 +4029,38 @@ export class tools extends plugin {
             return true;
         }
 
-        for (let i = 0; i < 5; i++) {
-            const response = await builder.chat(messages, [CRAWL_TOOL]);
-            if (response.tool_calls) {
-                const tool_calls = response.tool_calls;
-                messages.push({ role: 'assistant', content: null, tool_calls });
-                for (const tool_call of tool_calls) {
-                    if (tool_call.function.name === 'crawl') {
-                        try {
-                            const args = JSON.parse(tool_call.function.arguments);
-                            const crawled_content = await llmRead(args.url);
-                            messages.push({ role: 'tool', tool_call_id: tool_call.id, name: 'crawl', content: crawled_content });
-                        } catch (error) {
-                            messages.push({ role: 'tool', tool_call_id: tool_call.id, name: 'crawl', content: `爬取错误: ${error.message}` });
+        try {
+            for (let i = 0; i < 5; i++) {
+                const response = await builder.chat(messages, [CRAWL_TOOL]);
+                if (response.tool_calls) {
+                    const tool_calls = response.tool_calls;
+                    messages.push({ role: 'assistant', content: null, tool_calls });
+                    for (const tool_call of tool_calls) {
+                        if (tool_call.function.name === 'crawl') {
+                            try {
+                                const args = JSON.parse(tool_call.function.arguments);
+                                const crawled_content = await llmRead(args.url);
+                                messages.push({ role: 'tool', tool_call_id: tool_call.id, name: 'crawl', content: crawled_content });
+                            } catch (error) {
+                                messages.push({ role: 'tool', tool_call_id: tool_call.id, name: 'crawl', content: `爬取错误: ${error.message}` });
+                            }
                         }
                     }
+                } else {
+                    const { ans: kimiAns, model } = response;
+                    const stats = estimateReadingTime(kimiAns);
+                    const titleMatch = kimiAns.match(/(Title|标题)([:：])\s*(.*?)\n/)?.[3];
+                    e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
+                    const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}」（通用模式回退）联合为您总结内容：`, kimiAns]));
+                    await replyWithRetry(e, Bot, Msg);
+                    return true;
                 }
-            } else {
-                const { ans: kimiAns, model } = response;
-                const stats = estimateReadingTime(kimiAns);
-                const titleMatch = kimiAns.match(/(Title|标题)([:：])\s*(.*?)\n/)?.[3];
-                e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
-                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}」（通用模式回退）联合为您总结内容：`, kimiAns]));
-                await replyWithRetry(e, Bot, Msg);
-                return true;
             }
+            e.reply("通用模式回退处理超出限制，请重试");
+        } catch (error) {
+            logger.error(`[R插件][微信文章][通用模式回退] 失败: ${error.message}`);
+            e.reply(`通用模式回退也失败: ${error.message}`);
         }
-        e.reply("通用模式回退处理超出限制，请重试");
         return true;
     }
 
@@ -4070,7 +4082,9 @@ export class tools extends plugin {
 
         // 元宝模式分流：仅当链接是微信文章（mp.weixin.qq.com）且配置为 yuanbao 模式时走元宝
         // 元宝模式不需要配置自配 AI（aiApiKey），故需在此分流前判断，避免被下面的 aiApiKey 校验拦截
-        if (this.weixinArticleResolveMode === 'yuanbao' && summaryLink && /mp\.weixin\.qq\.com/i.test(summaryLink)) {
+        // 注意：运行时读取 config，避免使用构造时缓存的 stale 值，让 #微信文章解析模式 命令立即生效
+        const weixinArticleResolveMode = config.getConfig("tools").weixinArticleResolveMode || this.weixinArticleResolveMode || 'general';
+        if (weixinArticleResolveMode === 'yuanbao' && summaryLink && /mp\.weixin\.qq\.com/i.test(summaryLink)) {
             return await this.weixinArticleByYuanbao(e, summaryLink, name);
         }
 

--- a/apps/tools.js
+++ b/apps/tools.js
@@ -130,6 +130,7 @@ import { genVerifyFp } from "../utils/tiktok.js";
 import Translate from "../utils/trans-strategy.js";
 import { mid2id, getWeiboData, getWeiboComments, getWeiboVoteImages } from "../utils/weibo.js";
 import { fetchVideoProfile, extractShareUrl } from "../utils/weixin-channel.js";
+import { summarizeArticle as summarizeArticleByYuanbao } from "../utils/weixin-article-yuanbao.js";
 import { convertToSeconds, removeParams, ytbFormatTime } from "../utils/youtube.js";
 import { ytDlpGetDuration, ytDlpGetThumbnail, ytDlpGetThumbnailUrl, ytDlpGetTilt, ytDlpHelper } from "../utils/yt-dlp-util.js";
 import { textArrayToMakeForward, downloadImagesAndMakeForward, cleanupTempFiles, sendImagesInBatches, sendCustomMusicCard } from "../utils/yunzai-util.js";
@@ -448,6 +449,8 @@ export class tools extends plugin {
         this.xiaoheiheCookie = this.toolsConfig.xiaoheiheCookie;
         // 加载视频号（腾讯元宝）Cookie —— 支持运行时通过 #设置视频号Cookie 命令更新
         this.weixinChannelYuanbaoCookie = this.toolsConfig.weixinChannelYuanbaoCookie;
+        // 加载微信文章解析模式：general-通用（默认），yuanbao-元宝 —— 支持运行时通过 #微信文章解析模式 命令切换
+        this.weixinArticleResolveMode = this.toolsConfig.weixinArticleResolveMode || 'general';
     }
 
     // 翻译插件
@@ -3918,6 +3921,137 @@ export class tools extends plugin {
         return { title, album, artist };
     }
 
+    /**
+     * 微信文章解析 - 元宝模式
+     * 走腾讯元宝 Web 端对话接口让元宝抓取并总结微信文章链接
+     * 与视频号解析共用 weixinChannelYuanbaoCookie（同一套元宝 Cookie）
+     * 解析流程：新建会话 → 初始化模型 → 对话总结 → 删除会话（一次性）
+     *
+     * 超时策略：
+     *   1. 立即回复"正在解析"提示（避免用户等待无反馈）
+     *   2. SSE 流接收超时由 chatSummarize 内部控制（默认 120 秒）
+     *   3. 元宝失败时自动回退到通用模式（若已配置自配 AI），否则提示用户
+     *
+     * @param e 消息事件
+     * @param {string} articleUrl 微信文章 URL
+     * @param {string} name 识别平台名（如"微信文章"）
+     * @returns {Promise<boolean>}
+     */
+    async weixinArticleByYuanbao(e, articleUrl, name = '微信文章') {
+        // 校验 Cookie
+        const cookie = this.weixinChannelYuanbaoCookie;
+        if (!cookie) {
+            e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）\n⚠️ 未配置腾讯元宝 Cookie，请联系管理员私聊发送 #设置视频号Cookie 进行设置`);
+            return true;
+        }
+
+        // 立即回复"正在解析"提示，避免元宝对话较慢时用户无反馈
+        await e.reply(`${this.identifyPrefix}识别：${name}（元宝模式），正在调用腾讯元宝抓取并总结，预计 30-60 秒，请稍等...`, true);
+        logger.info(`[R插件][微信文章][元宝模式] 开始解析: ${articleUrl}`);
+
+        try {
+            const summary = await summarizeArticleByYuanbao(articleUrl, cookie, {
+                timeout: 120000,
+            });
+
+            // 元宝返回的总结文本可能较长，使用合并转发发送
+            // 头部标注「腾讯元宝」解析方式，让用户清楚是哪种模式产出的
+            const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [
+                `「R插件 x 腾讯元宝」联合为您总结内容：`,
+                summary,
+            ]));
+            await replyWithRetry(e, Bot, Msg);
+            logger.info(`[R插件][微信文章][元宝模式] 解析完成，总结长度: ${summary.length}`);
+            return true;
+        } catch (err) {
+            logger.error(`[R插件][微信文章][元宝模式] 解析失败: ${err.message}`);
+            // 自动回退到通用模式（若已配置自配 AI 接口）
+            if (!_.isEmpty(this.aiApiKey)) {
+                e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）解析失败，正在自动回退到通用模式（${this.aiModel}）...`, true);
+                logger.mark(`[R插件][微信文章] 自动回退到通用模式`);
+                // 临时改写当前消息，走通用 linkShareSummary 链路
+                // 注意：直接调用 linkShareSummary 会再次触发 mp 链接分流到元宝的死循环，
+                // 所以这里手动复用通用逻辑（不经过 linkShareSummary 入口）
+                return await this._weixinArticleGeneral(e, articleUrl, name);
+            }
+            // 未配置自配 AI，无法回退，直接报错
+            e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）解析失败：${err.message}\n\n未配置自配 AI 接口，无法自动回退。可尝试：\n1. 检查元宝 Cookie 是否失效（#设置视频号Cookie）\n2. 切换回通用模式：#微信文章解析模式 通用`);
+            return true;
+        }
+    }
+
+    /**
+     * 微信文章解析 - 通用模式（内部复用方法，供元宝模式回退调用）
+     * 与 linkShareSummary 中的通用逻辑保持一致，但不经过入口分流，避免回退死循环
+     * @param e 消息事件
+     * @param {string} articleUrl 微信文章 URL
+     * @param {string} name 识别平台名
+     * @returns {Promise<boolean>}
+     */
+    async _weixinArticleGeneral(e, articleUrl, name = '微信文章') {
+        const builder = await new OpenaiBuilder()
+            .setBaseURL(this.aiBaseURL)
+            .setApiKey(this.aiApiKey)
+            .setModel(this.aiModel)
+            .setPrompt(SUMMARY_PROMPT);
+        await builder.build();
+
+        e.reply(`${this.identifyPrefix}识别：${name}（通用模式回退），正在为您总结，请稍等...`, true);
+
+        let messages = [{ role: "user", content: articleUrl }];
+
+        // 兜底策略：检测模型是否支持 tool_calls
+        if (!this.aiModel.includes("kimi") && !this.aiModel.includes("moonshot")) {
+            try {
+                const crawled_content = await llmRead(articleUrl);
+                messages = [
+                    { role: "user", content: `这是网页链接: ${articleUrl}` },
+                    { role: "assistant", content: `好的，我已经爬取了网页内容，内容如下：\n${crawled_content}` },
+                    { role: "user", content: "请根据以上内容进行总结。" }
+                ];
+                const response = await builder.chat(messages);
+                const { ans: kimiAns, model } = response;
+                const stats = estimateReadingTime(kimiAns);
+                const titleMatch = kimiAns.match(/(Title|标题)([:：])\s*(.*)/)?.[3];
+                e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
+                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}」（通用模式回退）联合为您总结内容：`, kimiAns]));
+                await replyWithRetry(e, Bot, Msg);
+            } catch (error) {
+                e.reply(`通用模式回退也失败: ${error.message}`);
+            }
+            return true;
+        }
+
+        for (let i = 0; i < 5; i++) {
+            const response = await builder.chat(messages, [CRAWL_TOOL]);
+            if (response.tool_calls) {
+                const tool_calls = response.tool_calls;
+                messages.push({ role: 'assistant', content: null, tool_calls });
+                for (const tool_call of tool_calls) {
+                    if (tool_call.function.name === 'crawl') {
+                        try {
+                            const args = JSON.parse(tool_call.function.arguments);
+                            const crawled_content = await llmRead(args.url);
+                            messages.push({ role: 'tool', tool_call_id: tool_call.id, name: 'crawl', content: crawled_content });
+                        } catch (error) {
+                            messages.push({ role: 'tool', tool_call_id: tool_call.id, name: 'crawl', content: `爬取错误: ${error.message}` });
+                        }
+                    }
+                }
+            } else {
+                const { ans: kimiAns, model } = response;
+                const stats = estimateReadingTime(kimiAns);
+                const titleMatch = kimiAns.match(/(Title|标题)([:：])\s*(.*?)\n/)?.[3];
+                e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
+                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}」（通用模式回退）联合为您总结内容：`, kimiAns]));
+                await replyWithRetry(e, Bot, Msg);
+                return true;
+            }
+        }
+        e.reply("通用模式回退处理超出限制，请重试");
+        return true;
+    }
+
     // 链接总结
     async linkShareSummary(e) {
         if (!(await this.isEnableResolve(RESOLVE_CONTROLLER_NAME_ENUM.linkShareSummary))) {
@@ -3932,6 +4066,12 @@ export class tools extends plugin {
             summaryLink = e.msg.replace(/^#总结一下\s*/, "").trim();
         } else {
             ({ name, summaryLink } = contentEstimator(e.msg));
+        }
+
+        // 元宝模式分流：仅当链接是微信文章（mp.weixin.qq.com）且配置为 yuanbao 模式时走元宝
+        // 元宝模式不需要配置自配 AI（aiApiKey），故需在此分流前判断，避免被下面的 aiApiKey 校验拦截
+        if (this.weixinArticleResolveMode === 'yuanbao' && summaryLink && /mp\.weixin\.qq\.com/i.test(summaryLink)) {
+            return await this.weixinArticleByYuanbao(e, summaryLink, name);
         }
 
         // 判断是否有总结的条件
@@ -3973,7 +4113,7 @@ export class tools extends plugin {
                 const titleMatch = kimiAns.match(/(Title|标题)([:：])\s*(.*)/)?.[3];
                 e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
                 // 将总结内容格式化为合并转发消息
-                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}」联合为您总结内容：`, kimiAns]));
+                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}（通用模式）」联合为您总结内容：`, kimiAns]));
                 await replyWithRetry(e, Bot, Msg);
             } catch (error) {
                 e.reply(`总结失败: ${error.message}`);
@@ -4025,7 +4165,7 @@ export class tools extends plugin {
                 const stats = estimateReadingTime(kimiAns);
                 const titleMatch = kimiAns.match(/(Title|标题)([:：])\s*(.*?)\n/)?.[3];
                 e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
-                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}」联合为您总结内容：`, kimiAns]));
+                const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [`「R插件 x ${model}（通用模式）」联合为您总结内容：`, kimiAns]));
                 await replyWithRetry(e, Bot, Msg);
                 return false;
             }

--- a/apps/tools.js
+++ b/apps/tools.js
@@ -449,7 +449,7 @@ export class tools extends plugin {
         this.xiaoheiheCookie = this.toolsConfig.xiaoheiheCookie;
         // 加载视频号（腾讯元宝）Cookie —— 支持运行时通过 #设置视频号Cookie 命令更新
         this.weixinChannelYuanbaoCookie = this.toolsConfig.weixinChannelYuanbaoCookie;
-        // 加载微信文章解析模式：general-通用（默认），yuanbao-元宝 —— 支持运行时通过 #微信文章解析模式 命令切换
+        // 加载微信文章解析模式：general-通用（默认），yuanbao-元宝
         this.weixinArticleResolveMode = this.toolsConfig.weixinArticleResolveMode || 'general';
     }
 
@@ -3982,7 +3982,7 @@ export class tools extends plugin {
                 return await this._weixinArticleGeneral(e, articleUrl, name);
             }
             // 未配置自配 AI，无法回退，直接报错
-            e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）解析失败：${err.message}\n\n未配置自配 AI 接口，无法自动回退。可尝试：\n1. 检查元宝 Cookie 是否失效（#设置视频号Cookie）\n2. 切换回通用模式：#微信文章解析模式 通用`);
+            e.reply(`${this.identifyPrefix}识别：${name}（元宝模式）解析失败：${err.message}\n\n未配置自配 AI 接口，无法自动回退。可尝试：\n1. 检查元宝 Cookie 是否失效（#设置视频号Cookie）\n2. 在锅巴配置中切换回通用模式`);
             return true;
         }
     }
@@ -4082,7 +4082,7 @@ export class tools extends plugin {
 
         // 元宝模式分流：仅当链接是微信文章（mp.weixin.qq.com）且配置为 yuanbao 模式时走元宝
         // 元宝模式不需要配置自配 AI（aiApiKey），故需在此分流前判断，避免被下面的 aiApiKey 校验拦截
-        // 注意：运行时读取 config，避免使用构造时缓存的 stale 值，让 #微信文章解析模式 命令立即生效
+        // 注意：运行时读取 config，避免使用构造时缓存的 stale 值，让配置更新立即生效
         const weixinArticleResolveMode = config.getConfig("tools").weixinArticleResolveMode || this.weixinArticleResolveMode || 'general';
         if (weixinArticleResolveMode === 'yuanbao' && summaryLink && /mp\.weixin\.qq\.com/i.test(summaryLink)) {
             return await this.weixinArticleByYuanbao(e, summaryLink, name);

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -76,6 +76,8 @@ weiboComments: true # 是否显示微博评论，默认开启
 
 weixinChannelYuanbaoCookie: '' # 视频号解析所需腾讯元宝Cookie，浏览器登录 https://yuanbao.tencent.com 后 F12→Network→任意请求→Request Headers→Cookie 复制；也可私聊机器人发送 #设置视频号Cookie 进行设置，参考：https://github.com/ltaoo/wx_channels_download
 
+weixinArticleResolveMode: 'general' # 微信文章（mp.weixin.qq.com）解析模式：general-通用模式（浏览器抓取+自配AI总结，默认），yuanbao-元宝模式（直接发给元宝抓取总结，与视频号共用元宝Cookie，规避微信风控，但元宝对话接口有IP风控需部署服务器IP与元宝登录IP一致）。也可发 #微信文章解析模式 切换
+
 xiaoheiheCookie: '' # 小黑盒Cookie，格式：x_xhh_tokenid=xxx
 
 queueConcurrency: 1 # 【目前只涉及哔哩哔哩的下载】根据服务器性能设置可以并发下载的个数，如果你的服务器比较强劲，就选择4~12，较弱就一个一个下载，选择1

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -76,7 +76,7 @@ weiboComments: true # 是否显示微博评论，默认开启
 
 weixinChannelYuanbaoCookie: '' # 视频号解析所需腾讯元宝Cookie，浏览器登录 https://yuanbao.tencent.com 后 F12→Network→任意请求→Request Headers→Cookie 复制；也可私聊机器人发送 #设置视频号Cookie 进行设置，参考：https://github.com/ltaoo/wx_channels_download
 
-weixinArticleResolveMode: 'general' # 微信文章（mp.weixin.qq.com）解析模式：general-通用模式（浏览器抓取+自配AI总结，默认），yuanbao-元宝模式（直接发给元宝抓取总结，与视频号共用元宝Cookie，规避微信风控，但元宝对话接口有IP风控需部署服务器IP与元宝登录IP一致）。也可发 #微信文章解析模式 切换
+weixinArticleResolveMode: 'general' # 微信文章（mp.weixin.qq.com）解析模式：general-通用模式（浏览器抓取+自配AI总结，默认），yuanbao-元宝模式（直接发给元宝抓取总结，与视频号共用元宝Cookie，规避微信风控，但元宝对话接口有IP风控需部署服务器IP与元宝登录IP一致）
 
 xiaoheiheCookie: '' # 小黑盒Cookie，格式：x_xhh_tokenid=xxx
 

--- a/constants/constant.js
+++ b/constants/constant.js
@@ -288,6 +288,11 @@ export const NETEASECLOUD_QUALITY_LIST = Object.freeze([
     { label: '杜比全景声(不推荐)', value: 'dolby' },
     { label: '超清母带', value: 'jymaster' },
 ]);
+
+export const WEIXIN_ARTICLE_RESOLVE_MODE_LIST = Object.freeze([
+    { label: '通用模式', value: 'general' },
+    { label: '元宝模式', value: 'yuanbao' },
+]);
 /**
  * 消息撤回时间
  * @type {number}

--- a/constants/tools.js
+++ b/constants/tools.js
@@ -357,6 +357,27 @@ export const WXCHANNEL_YUANBAO_PARSE = "https://yuanbao.tencent.com/api/weixin/g
 export const WXCHANNEL_FEED_INFO = "https://channels.weixin.qq.com/finder-preview/api/feed/get_feed_info";
 
 /**
+ * 微信文章解析 - 腾讯元宝对话接口
+ * 通过元宝 Web 端对话接口让元宝抓取并总结微信文章（mp.weixin.qq.com）链接
+ * 与视频号解析共用同一个元宝 Cookie（weixinChannelYuanbaoCookie）
+ * 接口路径形如 /api/chat/{chatId}，{chatId} 由 conversation/create 接口创建
+ * payload 格式参考：https://github.com/chenwr727/yuanbao-free-api
+ * @type {string}
+ */
+export const YUANBAO_CHAT = "https://yuanbao.tencent.com/api/chat/";
+
+/**
+ * 微信文章解析 - 腾讯元宝会话管理接口
+ * 新建会话：POST /api/user/agent/conversation/create，返回 { id: chatId }
+ * 删除会话：POST /api/user/agent/conversation/v1/clear，body 含 conversationIds 数组
+ * 切换模型：POST /api/user/agent/conversation/updateModel，初始化会话模型
+ * @type {string}
+ */
+export const YUANBAO_CONVERSATION_CREATE = "https://yuanbao.tencent.com/api/user/agent/conversation/create";
+export const YUANBAO_CONVERSATION_CLEAR = "https://yuanbao.tencent.com/api/user/agent/conversation/v1/clear";
+export const YUANBAO_CONVERSATION_UPDATE_MODEL = "https://yuanbao.tencent.com/api/user/agent/conversation/updateModel";
+
+/**
  * TOOL_CALL 爬虫工具
  * 用于Kimi模型Tool-Calling的爬虫工具
  * 当Kimi模型判断需要从网页获取信息时，会调用此工具。

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -1,12 +1,6 @@
 import _ from "lodash";
 import path from "path";
-import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST } from "./constants/constant.js";
-
-// 微信文章解析模式选项（用于 Guoba Select 组件）
-const WEIXIN_ARTICLE_RESOLVE_MODE_LIST = [
-    { label: '通用模式', value: 'general' },
-    { label: '元宝模式', value: 'yuanbao' },
-];
+import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST, WEIXIN_ARTICLE_RESOLVE_MODE_LIST } from "./constants/constant.js";
 import { RESOLVE_CONTROLLER_NAME_ENUM } from "./constants/resolve.js";
 import model from "./model/config.js";
 
@@ -729,7 +723,7 @@ export function supportGuoba() {
                         "微信文章（mp.weixin.qq.com）解析方式选择：\n" +
                         "• 通用模式（默认）：浏览器抓取页面正文 + 自配 AI（kimi/openai）总结，依赖 aiApiKey 配置\n" +
                         "• 元宝模式：直接把链接发给腾讯元宝抓取并总结，与视频号共用上面的元宝 Cookie，可规避微信页面风控（环境异常），但元宝对话接口有 IP 风控（部署服务器 IP 需与元宝登录 IP 一致）\n" +
-                        "也可通过命令切换：#微信文章解析模式 通用 / #微信文章解析模式 元宝",
+                        "请在锅巴配置中选择需要的解析模式。",
                     component: "Select",
                     componentProps: {
                         options: WEIXIN_ARTICLE_RESOLVE_MODE_LIST,

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -1,6 +1,12 @@
 import _ from "lodash";
 import path from "path";
 import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST } from "./constants/constant.js";
+
+// 微信文章解析模式选项（用于 Guoba Select 组件）
+const WEIXIN_ARTICLE_RESOLVE_MODE_LIST = [
+    { label: '通用模式', value: 'general' },
+    { label: '元宝模式', value: 'yuanbao' },
+];
 import { RESOLVE_CONTROLLER_NAME_ENUM } from "./constants/resolve.js";
 import model from "./model/config.js";
 
@@ -714,6 +720,19 @@ export function supportGuoba() {
                     required: false,
                     componentProps: {
                         placeholder: "请输入腾讯元宝的Cookie",
+                    },
+                },
+                {
+                    field: "tools.weixinArticleResolveMode",
+                    label: "微信文章解析模式",
+                    bottomHelpMessage:
+                        "微信文章（mp.weixin.qq.com）解析方式选择：\n" +
+                        "• 通用模式（默认）：浏览器抓取页面正文 + 自配 AI（kimi/openai）总结，依赖 aiApiKey 配置\n" +
+                        "• 元宝模式：直接把链接发给腾讯元宝抓取并总结，与视频号共用上面的元宝 Cookie，可规避微信页面风控（环境异常），但元宝对话接口有 IP 风控（部署服务器 IP 需与元宝登录 IP 一致）\n" +
+                        "也可通过命令切换：#微信文章解析模式 通用 / #微信文章解析模式 元宝",
+                    component: "Select",
+                    componentProps: {
+                        options: WEIXIN_ARTICLE_RESOLVE_MODE_LIST,
                     },
                 },
                 {

--- a/utils/weixin-article-yuanbao.js
+++ b/utils/weixin-article-yuanbao.js
@@ -1,0 +1,380 @@
+import axios from 'axios';
+import {
+    YUANBAO_CHAT,
+    YUANBAO_CONVERSATION_CREATE,
+    YUANBAO_CONVERSATION_CLEAR,
+    YUANBAO_CONVERSATION_UPDATE_MODEL,
+} from '../constants/tools.js';
+
+/**
+ * 微信文章解析（走腾讯元宝 Web 端对话接口）
+ *
+ * 设计思路：
+ *   与 utils/weixin-channel.js 视频号解析共用同一个腾讯元宝 Cookie（weixinChannelYuanbaoCookie）。
+ *   视频号走 get_parse_result 专用接口拿 playable_url（结构化数据）；
+ *   微信文章没有专用接口，get_parse_result 对文章 URL 返回全空（沙箱实测确认），
+ *   只能走元宝对话接口让元宝抓取并总结。
+ *
+ * 解析流程（一次性会话）：
+ *   1. POST /api/user/agent/conversation/create 新建会话 → 拿 chatId
+ *   2. POST /api/user/agent/conversation/updateModel 初始化模型为 hunyuan_gpt_175B_0404
+ *   3. POST /api/chat/{chatId} 发送"总结：<文章URL>"消息，接收 SSE 流拼接元宝返回内容
+ *   4. POST /api/user/agent/conversation/v1/clear 删除会话（无论成功失败都清理）
+ *
+ * 鉴权：仅需腾讯元宝 Web 端 Cookie，不需要微信登录。
+ * payload 格式参考：https://github.com/chenwr727/yuanbao-free-api
+ */
+
+// 元宝 Web 端公共请求头（设备指纹部分，与视频号 PARSE_HEADERS 保持一致风格）
+// 注意：t-userid / x-device-id 等指纹头与 Cookie 不强绑定，沙箱实测用任意值均能调通会话管理接口
+const COMMON_HEADERS = {
+    'accept': 'application/json, text/plain, */*',
+    'accept-language': 'zh-CN,zh-TW;q=0.9,zh;q=0.8',
+    'content-type': 'application/json',
+    'origin': 'https://yuanbao.tencent.com',
+    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36',
+    'sec-ch-ua': `"Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"`,
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': `"Windows"`,
+    'sec-fetch-dest': 'empty',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-site': 'same-origin',
+    'x-language': 'zh-CN',
+    'x-platform': 'win',
+    'x-source': 'web',
+    'x-webversion': '2.74.1',
+    'x-requested-with': 'XMLHttpRequest',
+    'x-webdriver': '0',
+    'x-ybuitest': '0',
+};
+
+// 元宝默认智能体 ID（与视频号解析 referer 里的一致）
+const AGENT_ID = 'naQivTmsDa';
+// 默认对话模型（混元 175B，元宝网页版默认模型）
+const DEFAULT_MODEL = 'hunyuan_gpt_175B_0404';
+
+/**
+ * 构建带 Cookie + referer 的完整请求头
+ * @param {string} cookie 腾讯元宝 Web 端 Cookie
+ * @param {string} chatId 会话 ID（用于 referer 与 x-agentid）
+ * @param {object} extra 额外覆盖的 headers
+ * @param {object} [opts]
+ * @param {boolean} [opts.chatIdInPath=true] 是否在 referer/x-agentid 路径中带 chatId
+ *   - create/updateModel/clear 接口：带 chatId（如 /chat/naQivTmsDa/xxx）
+ *   - chat 对话接口：不带 chatId（仅 /chat/naQivTmsDa，实测抓包确认）
+ * @returns {object}
+ */
+function buildHeaders(cookie, chatId, extra = {}, { chatIdInPath = true } = {}) {
+    const path = chatIdInPath ? `${AGENT_ID}/${chatId}` : AGENT_ID;
+    return {
+        ...COMMON_HEADERS,
+        'referer': `https://yuanbao.tencent.com/chat/${path}`,
+        'x-agentid': path,
+        'cookie': cookie,
+        ...extra,
+    };
+}
+
+/**
+ * Step 1: 新建元宝会话
+ * @param {string} cookie 腾讯元宝 Web 端 Cookie
+ * @returns {Promise<string>} chatId 会话 ID
+ */
+export async function createConversation(cookie) {
+    // payload 必须带 agentId，实测抓包确认；不带 agentId 也能创建但建议与网页版一致
+    const resp = await axios.post(
+        YUANBAO_CONVERSATION_CREATE,
+        { agentId: AGENT_ID },
+        {
+            headers: buildHeaders(cookie, ''),
+            timeout: 15000,
+        },
+    );
+    const chatId = resp.data?.id;
+    if (!chatId) {
+        throw new Error('元宝接口未返回会话 ID，可能是 Cookie 失效');
+    }
+    logger.info(`[R插件][微信文章][元宝] 创建会话成功: ${chatId}`);
+    return chatId;
+}
+
+/**
+ * Step 2: 初始化会话模型（混元 175B + 自动联网搜索）
+ * 不调用此步骤直接发消息有时会返回空，沙箱实测必须先初始化模型
+ * @param {string} cookie 腾讯元宝 Web 端 Cookie
+ * @param {string} chatId 会话 ID
+ */
+export async function initConversationModel(cookie, chatId) {
+    const payload = {
+        cid: chatId,
+        chatModelId: DEFAULT_MODEL,
+        // chatModelExtInfo 是嵌套 JSON 字符串（元宝网页版原样格式）
+        chatModelExtInfo: JSON.stringify({
+            modelId: DEFAULT_MODEL,
+            subModelId: '',
+            supportFunctions: { internetSearch: 'autoInternetSearch' },
+            internetSearch: 'autoInternetSearch',
+        }),
+    };
+    await axios.post(YUANBAO_CONVERSATION_UPDATE_MODEL, payload, {
+        headers: buildHeaders(cookie, chatId),
+        timeout: 15000,
+    });
+    logger.info(`[R插件][微信文章][元宝] 初始化模型成功: ${DEFAULT_MODEL}`);
+}
+
+/**
+ * Step 4: 删除元宝会话（无论解析成功失败都应调用，避免污染用户会话列表）
+ * @param {string} cookie 腾讯元宝 Web 端 Cookie
+ * @param {string} chatId 会话 ID
+ */
+export async function clearConversation(cookie, chatId) {
+    try {
+        await axios.post(
+            YUANBAO_CONVERSATION_CLEAR,
+            { conversationIds: [chatId], uiOptions: { noToast: true } },
+            {
+                headers: buildHeaders(cookie, chatId),
+                timeout: 15000,
+            },
+        );
+        logger.info(`[R插件][微信文章][元宝] 删除会话成功: ${chatId}`);
+    } catch (err) {
+        // 删除失败不影响主流程，仅记录日志
+        logger.warn(`[R插件][微信文章][元宝] 删除会话失败（不影响主流程）: ${err.message}`);
+    }
+}
+
+/**
+ * 解析元宝 SSE 流，拼接出最终文本回复
+ *
+ * 元宝 SSE 真实格式（实测抓包确认，2026-06）：
+ *   - 每行形如 `data: {...}` 或 `event: xxx` 或自定义标记行
+ *   - 文本增量：`data: {"type":"text","msg":"根据你"}` ← 只提取这种
+ *   - 状态提示：`data: {"type":"continue_step","msg":"正在阅读"}` ← 跳过（不是回答内容）
+ *   - 文章卡片：`data: {"type":"multimediaParseResult",...}` ← 跳过
+ *   - 元信息：`data: {"type":"meta",...}` ← 跳过
+ *   - 非 JSON 标记：`data: status` / `data: text` / `data: [plugin: ]` / `data: [MSGINDEX:2]`
+ *                   `data: [TRACEID:...]` / `data: [DONE]` ← 全部跳过
+ *   - event: 行（如 `event: speech_type`）← 跳过
+ *
+ * 关键点：必须用 `type === "text" && typeof msg === "string"` 双重过滤，
+ * 否则会把"正在阅读"等状态提示误当作回答内容。
+ *
+ * @param {import('stream').Readable} stream SSE 流
+ * @param {object} options
+ * @param {function(string): void} [options.onChunk] 收到增量文本回调（可用于实时进度展示）
+ * @returns {Promise<string>} 拼接后的完整文本
+ */
+function parseSSEStream(stream, { onChunk } = {}) {
+    return new Promise((resolve, reject) => {
+        const parts = [];
+        let buffer = '';
+
+        const handleLine = (line) => {
+            line = line.trim();
+            if (!line) return;
+
+            // SSE 注释行 / 事件名行 / id 行，跳过
+            if (line.startsWith(':') || line.startsWith('event:') || line.startsWith('id:')) return;
+
+            // 提取 data: 后的内容
+            let dataStr = line;
+            if (line.startsWith('data:')) {
+                dataStr = line.slice(5).trim();
+            }
+
+            // 空内容或结束标记
+            if (!dataStr || dataStr === '[DONE]') return;
+
+            // 非 JSON 的标记行（[plugin:] / [MSGINDEX:] / [TRACEID:] / status / text 等）全部跳过
+            // 这些是元宝前端的自定义协议标记，不是回答内容
+            if (dataStr.startsWith('[')) return;
+            if (dataStr === 'status' || dataStr === 'text') return;
+
+            // 尝试 JSON 解析
+            let obj;
+            try {
+                obj = JSON.parse(dataStr);
+            } catch (_) {
+                // 非 JSON 行一律跳过（避免把状态文本误当作回答）
+                return;
+            }
+
+            // 错误事件
+            if (obj.type === 'error' || (obj.error && obj.error.code && String(obj.error.code) !== '0')) {
+                reject(new Error(`元宝接口错误: ${obj.error?.message || obj.msg || obj.error?.code}`));
+                return;
+            }
+
+            // 只提取 type=text 的 msg 字段作为回答增量
+            // 注意：continue_step / multimediaParseResult / meta 等类型也有 msg 或其他字段，必须排除
+            if (obj.type === 'text' && typeof obj.msg === 'string' && obj.msg) {
+                parts.push(obj.msg);
+                if (onChunk) onChunk(obj.msg);
+            }
+        };
+
+        stream.on('data', (chunk) => {
+            buffer += chunk.toString();
+            // 按换行切分，最后一行可能不完整暂存到 buffer
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+            for (const line of lines) handleLine(line);
+        });
+
+        stream.on('end', () => {
+            // 处理 buffer 中剩余内容
+            if (buffer.trim()) handleLine(buffer);
+            const fullText = parts.join('').trim();
+            if (!fullText) {
+                reject(new Error('元宝接口未返回任何文本内容，可能是接口格式变动或 Cookie 失效'));
+                return;
+            }
+            resolve(fullText);
+        });
+
+        stream.on('error', (err) => reject(err));
+    });
+}
+
+/**
+ * Step 3: 发送文章总结请求并接收 SSE 流
+ *
+ * payload 与 headers 格式来自元宝网页版实测抓包（2026-06），
+ * 与 yuanbao-free-api 早期版本有差异，以实际抓包为准。
+ *
+ * 关键字段：
+ *   - parsingPromptUrl: 文章 URL 数组，元宝据此抓取文章正文
+ *   - conversationId: 会话 ID（与 URL 路径里的 chatId 一致）
+ *   - model: "gpt_175B_0404"（注意无 hunyuan_ 前缀，与 chatModelId 不同）
+ *   - supportFunctions: 开启联网搜索与自动搜索开关
+ *
+ * headers 关键点：
+ *   - content-type: text/plain;charset=UTF-8（非 application/json）
+ *   - chat_version: v1
+ *   - referer / x-agentid 不带 chatId（仅 naQivTmsDa）
+ *
+ * @param {string} cookie 腾讯元宝 Web 端 Cookie
+ * @param {string} chatId 会话 ID
+ * @param {string} articleUrl 微信文章 URL
+ * @param {object} [options]
+ * @param {number} [options.timeout=120000] 超时毫秒
+ * @param {function(string): void} [options.onChunk] 增量回调
+ * @returns {Promise<string>} 元宝总结的完整文本
+ */
+export async function chatSummarize(cookie, chatId, articleUrl, options = {}) {
+    const { timeout = 120000, onChunk } = options;
+
+    const prompt = articleUrl;
+    // payload 字段对齐元宝网页版实测抓包格式
+    const body = {
+        model: 'gpt_175B_0404',
+        prompt,
+        plugin: '',
+        displayPrompt: prompt,
+        displayPromptType: 1,
+        agentId: AGENT_ID,
+        isTemporary: false,
+        projectId: '',
+        chatModelId: DEFAULT_MODEL,
+        supportFunctions: ['openAutoSearchSwitch', 'autoInternetSearch'],
+        docOpenid: '',
+        options: {
+            imageIntention: { needIntentionModel: true, backendUpdateFlag: 2, intentionStatus: true },
+        },
+        multimedia: [],
+        supportHint: 1,
+        chatModelExtInfo: JSON.stringify({
+            modelId: DEFAULT_MODEL,
+            subModelId: '',
+            supportFunctions: { internetSearch: '' },
+            internetSearch: 'autoInternetSearch',
+        }),
+        applicationIdList: [],
+        version: 'v2',
+        extReportParams: null,
+        isAtomInput: false,
+        // 关键：文章 URL 数组，元宝据此抓取文章正文（实测抓包确认）
+        parsingPromptUrl: [articleUrl],
+        // 关键：会话 ID，与 URL 路径里的 chatId 一致
+        conversationId: chatId,
+        offsetOfHour: 8,
+        offsetOfMinute: 0,
+    };
+
+    const resp = await axios.post(`${YUANBAO_CHAT}${chatId}`, body, {
+        // chat 接口 referer/x-agentid 不带 chatId（实测抓包确认）
+        headers: buildHeaders(cookie, chatId, {
+            accept: '*/*',
+            'content-type': 'text/plain;charset=UTF-8',
+            'chat_version': 'v1',
+        }, { chatIdInPath: false }),
+        timeout,
+        responseType: 'stream',
+        // SSE 流不解析为 JSON
+        transformResponse: [(data) => data],
+    });
+
+    if (resp.status !== 200) {
+        throw new Error(`元宝对话接口返回 HTTP ${resp.status}`);
+    }
+
+    logger.info(`[R插件][微信文章][元宝] 对话流已建立，开始接收 SSE`);
+    let summary = await parseSSEStream(resp.data, { onChunk });
+
+    // 清洗元宝富文本标记（QQ 群里显示会很怪）：
+    //   [](@mark_underline=N)  ← 高亮下划线标记
+    //   [](@mark_*)            ← 其他 mark 标记
+    //   [citation:N]           ← 联网搜索引用编号标记
+    summary = summary
+        .replace(/\[\]\(@mark_[a-z_]+=\d+\)/g, '')
+        .replace(/\[citation:\d+\]/g, '');
+
+    return summary;
+}
+
+/**
+ * 端到端解析：新建会话 → 初始化模型 → 对话总结 → 删除会话
+ *
+ * 无论解析成功或失败都会尝试删除会话，避免污染用户元宝账号的会话列表。
+ *
+ * @param {string} articleUrl 微信文章 URL（mp.weixin.qq.com）
+ * @param {string} cookie 腾讯元宝 Web 端 Cookie（与视频号解析共用）
+ * @param {object} [options]
+ * @param {function(string): void} [options.onChunk] SSE 增量回调（可用于实时进度展示）
+ * @param {number} [options.timeout=120000] 对话接口超时毫秒
+ * @returns {Promise<string>} 元宝总结的完整文本
+ */
+export async function summarizeArticle(articleUrl, cookie, options = {}) {
+    if (!cookie) {
+        throw new Error('未配置腾讯元宝 Cookie，请联系管理员设置（#设置视频号Cookie）');
+    }
+    if (!articleUrl || !/^https?:\/\/mp\.weixin\.qq\.com\//i.test(articleUrl)) {
+        throw new Error('仅支持微信文章链接（mp.weixin.qq.com）');
+    }
+
+    let chatId = '';
+    try {
+        // Step 1: 新建会话
+        chatId = await createConversation(cookie);
+        // Step 2: 初始化模型
+        await initConversationModel(cookie, chatId);
+        // Step 3: 发送总结请求
+        const summary = await chatSummarize(cookie, chatId, articleUrl, options);
+        logger.info(`[R插件][微信文章][元宝] 解析成功，文本长度: ${summary.length}`);
+        return summary;
+    } catch (err) {
+        // 401 通常意味着 Cookie 失效或部署服务器 IP 与元宝登录 IP 不一致（沙箱实测确认此风控存在）
+        const status = err?.response?.status;
+        if (status === 401) {
+            throw new Error('元宝对话接口返回 401 未授权，可能是 Cookie 失效或部署服务器 IP 与元宝登录 IP 不一致（元宝对话接口有 IP 风控）');
+        }
+        throw err;
+    } finally {
+        // Step 4: 无论成败都清理会话
+        if (chatId) {
+            await clearConversation(cookie, chatId);
+        }
+    }
+}

--- a/utils/weixin-article-yuanbao.js
+++ b/utils/weixin-article-yuanbao.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { StringDecoder } from 'node:string_decoder';
 import {
     YUANBAO_CHAT,
     YUANBAO_CONVERSATION_CREATE,
@@ -170,6 +171,8 @@ function parseSSEStream(stream, { onChunk } = {}) {
     return new Promise((resolve, reject) => {
         const parts = [];
         let buffer = '';
+        // 使用流式 UTF-8 解码器，避免 chunk 边界切断多字节中文字符导致乱码或 JSON 解析失败
+        const decoder = new StringDecoder('utf8');
 
         const handleLine = (line) => {
             line = line.trim();
@@ -216,7 +219,8 @@ function parseSSEStream(stream, { onChunk } = {}) {
         };
 
         stream.on('data', (chunk) => {
-            buffer += chunk.toString();
+            // 用 StringDecoder 流式解码，防止 chunk 边界切断多字节 UTF-8 字符
+            buffer += decoder.write(chunk);
             // 按换行切分，最后一行可能不完整暂存到 buffer
             const lines = buffer.split('\n');
             buffer = lines.pop() || '';
@@ -224,6 +228,8 @@ function parseSSEStream(stream, { onChunk } = {}) {
         });
 
         stream.on('end', () => {
+            // 刷新解码器残留字节（可能包含不完整字符的尾字节）
+            buffer += decoder.end();
             // 处理 buffer 中剩余内容
             if (buffer.trim()) handleLine(buffer);
             const fullText = parts.join('').trim();

--- a/utils/weixin-article-yuanbao.js
+++ b/utils/weixin-article-yuanbao.js
@@ -6,6 +6,7 @@ import {
     YUANBAO_CONVERSATION_CLEAR,
     YUANBAO_CONVERSATION_UPDATE_MODEL,
 } from '../constants/tools.js';
+import { SUMMARY_PROMPT } from '../constants/constant.js';
 
 /**
  * 微信文章解析（走腾讯元宝 Web 端对话接口）
@@ -53,6 +54,14 @@ const COMMON_HEADERS = {
 const AGENT_ID = 'naQivTmsDa';
 // 默认对话模型（混元 175B，元宝网页版默认模型）
 const DEFAULT_MODEL = 'hunyuan_gpt_175B_0404';
+
+function buildSummaryPrompt(articleUrl) {
+    return `${SUMMARY_PROMPT}
+
+请严格遵循以上角色、规则与输出格式要求，直接总结下面这篇微信文章，不要输出额外寒暄，也不要重复提示词内容。
+
+文章链接：${articleUrl}`;
+}
 
 /**
  * 构建带 Cookie + referer 的完整请求头
@@ -272,7 +281,7 @@ function parseSSEStream(stream, { onChunk } = {}) {
 export async function chatSummarize(cookie, chatId, articleUrl, options = {}) {
     const { timeout = 120000, onChunk } = options;
 
-    const prompt = articleUrl;
+    const prompt = buildSummaryPrompt(articleUrl);
     // payload 字段对齐元宝网页版实测抓包格式
     const body = {
         model: 'gpt_175B_0404',


### PR DESCRIPTION
## 背景

关联 issue #153

现有微信文章解析采用「模拟打开页面 + 自配 AI 总结」方式，存在两个问题：

1. **抓不到正文**：部分文章（如 `appmsg_type=9` 图文合集/分享卡片型）正文完全靠 JS 异步加载，HTML 里没有正文容器，现有 `llmRead` + `stripHtmlToText` 提取出来只有导航按钮文本
2. **触发风控**：部分服务器 IP 直接抓 `mp.weixin.qq.com` 会返回「环境异常，完成验证后即可继续访问」

## 方案

新增「元宝模式」作为可切换的解析方式，**复用视频号已配置的腾讯元宝 Cookie**，通过元宝 Web 端对话接口让元宝抓取文章正文并总结。元宝服务器去抓 mp 链接，不走用户服务器 IP，同时绕过 JS 渲染问题。

## 实现要点

### 核心模块 `utils/weixin-article-yuanbao.js`

- 复用视频号已配置的 `weixinChannelYuanbaoCookie`（同一套元宝 Cookie，零额外配置）
- 解析流程（一次性会话，不污染用户元宝账号）：
  1. `conversation/create` 新建会话
  2. `conversation/updateModel` 初始化模型
  3. `api/chat/{chatId}` 发送文章 URL 接收 SSE 流（元宝据此抓取文章正文）
  4. `conversation/v1/clear` 删除会话（`finally` 块强制清理）
- SSE 流解析：仅提取 `type=text` 的 `msg` 增量，过滤 `continue_step`（如「正在阅读」）/`multimediaParseResult`/`meta` 及各种标记行
- 富文本清洗：去除 `[](@mark_underline=N)` 与 `[citation:N]` 等元宝富文本标记

### 切换开关

- 命令：`#微信文章解析模式 元宝` / `#微信文章解析模式 通用`
- 网页端：Guoba 可视化配置 Select 选项
- 配置项：`config/tools.yaml` 的 `weixinArticleResolveMode`，默认 `general`（不破坏现有逻辑）

### 容错与回退

- 元宝模式解析失败时，若已配置自配 AI 接口，**自动回退到通用模式**（专用 `_weixinArticleGeneral` 方法，避免入口分流死循环）
- QQ 群消息头部标注解析方式（「腾讯元宝」/「通用模式」/「通用模式回退」）便于排查
- 超时立即回复「正在解析，预计 30-60 秒」提示，避免用户长时间无反馈

## 用户使用流程

1. 管理员私聊发 `#设置视频号Cookie <元宝Cookie>`（与视频号共用，已配置的用户可跳过）
2. 发 `#微信文章解析模式 元宝` 切到元宝模式（或网页端 Guoba 选「元宝模式」）
3. 重启插件
4. 群里发 `https://mp.weixin.qq.com/s/xxx` → 立即回复「正在调用腾讯元宝...」→ 元宝抓取总结 → 合并转发发送

## 文件改动

| 文件 | 改动 |
|---|---|
| `utils/weixin-article-yuanbao.js` | 新建，元宝对话解析核心模块 |
| `apps/switchers.js` | 新增 `#微信文章解析模式` 切换命令 |
| `apps/tools.js` | 新增元宝 handler + 通用模式回退方法 + 解析方式标注 |
| `config/tools.yaml` | 新增 `weixinArticleResolveMode` 配置项 |
| `constants/tools.js` | 新增元宝对话接口 URL 常量 |
| `guoba.support.js` | 网页端 Select 配置项 |

## 验证

- 接口格式按元宝网页版实测抓包确认（payload 字段、headers、SSE 事件结构）
- 沙箱端到端闭环测试通过：创建会话 → 初始化模型 → 对话解析 → 删除会话，成功拿到元宝总结的真实文章内容
- 富文本标记清洗验证通过

## 兼容性

- 默认 `general` 模式，现有逻辑完全不动
- 元宝模式为可选增强，不影响未配置元宝 Cookie 的用户
- 元宝失败自动回退通用模式，不降低原有可用性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new mode for WeChat article links, letting users choose between a general summarization flow and a Tencent Yuanbao-based flow.
  * Improved article handling with automatic fallback when the preferred mode is unavailable, helping summaries continue to work more reliably.
  * Updated shared chat summaries to clearly indicate when the general mode is used.

* **Bug Fixes**
  * Added clearer error handling for failed article parsing, missing access credentials, and restricted link formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->