### PR TITLE
feat: add KuGou audio quality selection

### DIFF
--- a/apps/tools.js
+++ b/apps/tools.js
@@ -364,6 +364,7 @@ export class tools extends plugin {
         // 酷狗开源API配置
         this.kugouApiServer = this.toolsConfig.kugouApiServer;
         this.kugouCookie = this.toolsConfig.kugouCookie;
+        this.kugouAudioQuality = this.toolsConfig.kugouAudioQuality || 'viper_clear';
         // 加载是否自建服务器
         this.useLocalNeteaseAPI = this.toolsConfig.useLocalNeteaseAPI;
         // 加载自建服务器API
@@ -4195,6 +4196,7 @@ export class tools extends plugin {
         const kugouResult = await resolveKugouMusicSource(this.kugouApiServer, {
             message: url,
             kugouCookie: this.kugouCookie,
+            quality: this.kugouAudioQuality,
         });
         for (const warning of kugouResult.warnings || []) {
             logger.warn(`[R插件][kugouMusic] ${warning}`);
@@ -4216,7 +4218,7 @@ export class tools extends plugin {
             cover: kugouResult.cover,
             songName: kugouResult.songName,
             singerName: kugouResult.singerName,
-            size: kugouResult.size,
+            size: kugouResult.qualityLabel || kugouResult.size,
             musicType: ["酷狗音乐"]
         });
         const img = await puppeteer.screenshot("neteaseMusicInfo", cardData);

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -69,6 +69,7 @@ msgElementLimit: 50 # 全局单条转发消息最大元素数（图+文混合）
 
 xiaohongshuCookie: '' # 2024-8-2后反馈必须使用ck，不然无法解析
 kugouApiServer: '' # 酷狗开源API服务地址，参考 KuGouMusicApi 默认端口
+kugouAudioQuality: viper_clear # 酷狗解析优先音质：viper_clear=Hi-Res, flac=无损FLAC, 320=高品320K, 128=普通128K
 kugouCookie: '' # 酷狗开源API搜索时使用的cookie，文档示例：token=xxx;userid=xxx;dfid=xxx
 
 weiboCookie: '' # 微博Cookie，格式：_T_WM=xxx; WEIBOCN_FROM=xxx; MLOGIN=xxx; XSRF-TOKEN=xxx; M_WEIBOCN_PARAMS=xxx

--- a/constants/constant.js
+++ b/constants/constant.js
@@ -289,6 +289,13 @@ export const NETEASECLOUD_QUALITY_LIST = Object.freeze([
     { label: '超清母带', value: 'jymaster' },
 ]);
 
+export const KUGOU_QUALITY_LIST = Object.freeze([
+    { label: 'Hi-Res', value: 'viper_clear' },
+    { label: '无损 FLAC', value: 'flac' },
+    { label: '高品 320K', value: '320' },
+    { label: '普通 128K', value: '128' },
+]);
+
 export const LINK_SUMMARY_RESOLVE_MODE_LIST = Object.freeze([
     { label: '通用模式', value: 'general' },
     { label: '元宝模式', value: 'yuanbao' },

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import path from "path";
-import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST, LINK_SUMMARY_RESOLVE_MODE_LIST } from "./constants/constant.js";
+import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, KUGOU_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST, LINK_SUMMARY_RESOLVE_MODE_LIST } from "./constants/constant.js";
 import { RESOLVE_CONTROLLER_NAME_ENUM } from "./constants/resolve.js";
 import model from "./model/config.js";
 
@@ -738,6 +738,16 @@ export function supportGuoba() {
                     componentProps: {
                         placeholder: "请输入酷狗开源API地址",
                     },
+                },
+                {
+                    field: "tools.kugouAudioQuality",
+                    label: "酷狗解析音质",
+                    bottomHelpMessage:
+                        "酷狗歌曲解析优先选择的音质，若目标歌曲不支持则自动降级",
+                    component: "Select",
+                    componentProps: {
+                        options: KUGOU_QUALITY_LIST,
+                    }
                 },
                 {
                     field: "tools.kugouCookie",

--- a/utils/kugou.js
+++ b/utils/kugou.js
@@ -864,7 +864,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
             cover = cover || officialSongInfo?.cover || "";
             albumId = albumId || officialSongInfo?.albumId || "";
             albumAudioId = albumAudioId || officialSongInfo?.albumAudioId || "";
-            musicInfo = musicInfo || officialSongInfo?.audioName || createKugouFileName(songName, singerName, hash);
+            musicInfo = officialSongInfo?.audioName || musicInfo || createKugouFileName(songName, singerName, hash);
         } catch (error) {
             warnings.push(buildKugouWarning("根据官方歌曲信息补全元数据失败", error));
         }

--- a/utils/kugou.js
+++ b/utils/kugou.js
@@ -532,29 +532,35 @@ export async function getKugouSongUrl(apiServer, { hash, albumId = "", albumAudi
     const requestCookie = mergeCookies(cookie, registerResp.cookie);
     const qualityList = buildKugouQualityFallbackList(quality);
     const errors = [];
-    let requestHash = hash;
     let requestAlbumId = albumId;
     let requestAlbumAudioId = albumAudioId;
+    let songInfo = null;
 
     try {
-        const songInfo = await getKugouSongInfoByHash(hash, albumId, albumAudioId);
-        requestHash = pickKugouQualityHash(songInfo, quality, hash);
+        songInfo = await getKugouSongInfoByHash(hash, albumId, albumAudioId);
         requestAlbumId = songInfo?.albumId || albumId;
         requestAlbumAudioId = songInfo?.albumAudioId || albumAudioId;
-    } catch {
-        requestHash = hash;
-    }
+    } catch {}
 
     for (const qualityItem of qualityList) {
+        const currentRequestHash = songInfo
+            ? pickKugouQualityHash(songInfo, qualityItem, hash)
+            : hash;
         const params = {
-            hash: requestHash,
+            hash: currentRequestHash,
             free_part: freePart,
             quality: qualityItem,
             ...(requestAlbumId ? { album_id: requestAlbumId } : {}),
             ...(requestAlbumAudioId ? { album_audio_id: requestAlbumAudioId } : {}),
         };
 
-        const response = await requestKugouApi(apiServer, "/song/url", params, requestCookie);
+        let response = null;
+        try {
+            response = await requestKugouApi(apiServer, "/song/url", params, requestCookie);
+        } catch (error) {
+            errors.push(`${getKugouQualityLabel(qualityItem)}：${error.message}`);
+            continue;
+        }
         const url = findPlayableUrl(response.data);
         if (!url) {
             const errorMessage = findFieldDeep(response.data, ["error", "msg", "message"]) || "未返回音源地址";
@@ -575,7 +581,7 @@ export async function getKugouSongUrl(apiServer, { hash, albumId = "", albumAudi
             quality: qualityItem,
             qualityLabel: getKugouQualityLabel(qualityItem),
             cookie: response.cookie,
-            requestHash,
+            requestHash: currentRequestHash,
             error: findFieldDeep(response.data, ["error", "msg", "message"]),
         };
     }
@@ -937,6 +943,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
                 cover = urlResult.cover || candidate.cover || cover;
                 url = urlResult.url || "";
                 audioType = urlResult.audioType || audioType;
+                qualityLabel = urlResult.qualityLabel || qualityLabel;
                 size = urlResult.size || size;
                 musicInfo = candidate.audioName || createKugouFileName(songName, singerName, hash);
             }

--- a/utils/kugou.js
+++ b/utils/kugou.js
@@ -317,6 +317,49 @@ function buildKugouWarning(message, error) {
     return `${message}：${error.message}`;
 }
 
+function normalizeKugouQuality(quality = "") {
+    const normalizedQuality = String(quality || "").trim();
+    const qualityMap = {
+        hires: "viper_clear",
+        hi_res: "viper_clear",
+        sq: "high",
+        lossless: "flac",
+        standard: "128",
+    };
+    return qualityMap[normalizedQuality] || normalizedQuality || "viper_clear";
+}
+
+function buildKugouQualityFallbackList(quality = "") {
+    const qualityOrder = ["viper_clear", "flac", "high", "320", "128"];
+    const preferredQuality = normalizeKugouQuality(quality);
+    return [preferredQuality, ...qualityOrder.filter(item => item !== preferredQuality)];
+}
+
+function getKugouQualityLabel(quality = "") {
+    const qualityLabelMap = {
+        viper_clear: "Hi-Res",
+        flac: "无损 FLAC",
+        high: "无损 SQ",
+        320: "高品 320K",
+        128: "普通 128K",
+    };
+    return qualityLabelMap[quality] || quality;
+}
+
+function pickKugouQualityHash(songInfo = {}, quality = "", fallbackHash = "") {
+    const qualityHashes = songInfo.qualityHashes || {};
+    const normalizedQuality = normalizeKugouQuality(quality);
+    const qualityHashMap = {
+        viper_clear: [qualityHashes.high, qualityHashes.sq, qualityHashes[320], qualityHashes[128]],
+        flac: [qualityHashes.sq, qualityHashes.high, qualityHashes[320], qualityHashes[128]],
+        high: [qualityHashes.sq, qualityHashes.high, qualityHashes[320], qualityHashes[128]],
+        320: [qualityHashes[320], qualityHashes[128]],
+        128: [qualityHashes[128]],
+    };
+    return (qualityHashMap[normalizedQuality] || [])
+        .find(item => String(item || "").trim()) || fallbackHash;
+}
+
 function normalizeHashKey(hash = "") {
     return String(hash).trim().toLowerCase();
 }
@@ -391,7 +434,7 @@ async function searchKugouSongWithFallback(apiServer, keyword, kugouCookie = "")
     }
 }
 
-async function tryKugouSongCandidates(apiServer, candidateList = [], defaultCookie = "") {
+async function tryKugouSongCandidates(apiServer, candidateList = [], defaultCookie = "", quality = "") {
     const warnings = [];
     const dedupedCandidates = [];
     const seenHashes = new Set();
@@ -410,6 +453,7 @@ async function tryKugouSongCandidates(apiServer, candidateList = [], defaultCook
                 albumId: candidate.albumId || "",
                 albumAudioId: candidate.albumAudioId || "",
                 cookie: candidate.cookie || defaultCookie,
+                quality,
             });
             if (urlResult.url) {
                 return {
@@ -483,31 +527,69 @@ export async function searchKugouSong(apiServer, keyword, kugouCookie = "") {
     };
 }
 
-export async function getKugouSongUrl(apiServer, { hash, albumId = "", albumAudioId = "", cookie = "", freePart = 1 }) {
+export async function getKugouSongUrl(apiServer, { hash, albumId = "", albumAudioId = "", cookie = "", freePart = 0, quality = "" }) {
     const registerResp = await registerKugouDevice(apiServer);
     const requestCookie = mergeCookies(cookie, registerResp.cookie);
-    const params = {
-        hash,
-        free_part: freePart,
-        ...(albumId ? { album_id: albumId } : {}),
-        ...(albumAudioId ? { album_audio_id: albumAudioId } : {}),
-    };
+    const qualityList = buildKugouQualityFallbackList(quality);
+    const errors = [];
+    let requestHash = hash;
+    let requestAlbumId = albumId;
+    let requestAlbumAudioId = albumAudioId;
 
-    const response = await requestKugouApi(apiServer, "/song/url", params, requestCookie);
-    const url = findPlayableUrl(response.data);
-    const size = formatBytesToMb(findFieldDeep(response.data, ["filesize", "fileSize", "size"]));
-    const cover = normalizeKugouCoverUrl(
-        findFieldDeep(response.data, ["union_cover", "album_img", "imgUrl", "imgurl", "img", "cover"])
-    );
+    try {
+        const songInfo = await getKugouSongInfoByHash(hash, albumId, albumAudioId);
+        requestHash = pickKugouQualityHash(songInfo, quality, hash);
+        requestAlbumId = songInfo?.albumId || albumId;
+        requestAlbumAudioId = songInfo?.albumAudioId || albumAudioId;
+    } catch {
+        requestHash = hash;
+    }
+
+    for (const qualityItem of qualityList) {
+        const params = {
+            hash: requestHash,
+            free_part: freePart,
+            quality: qualityItem,
+            ...(requestAlbumId ? { album_id: requestAlbumId } : {}),
+            ...(requestAlbumAudioId ? { album_audio_id: requestAlbumAudioId } : {}),
+        };
+
+        const response = await requestKugouApi(apiServer, "/song/url", params, requestCookie);
+        const url = findPlayableUrl(response.data);
+        if (!url) {
+            const errorMessage = findFieldDeep(response.data, ["error", "msg", "message"]) || "未返回音源地址";
+            errors.push(`${getKugouQualityLabel(qualityItem)}：${errorMessage}`);
+            continue;
+        }
+
+        const size = formatBytesToMb(findFieldDeep(response.data, ["filesize", "fileSize", "size"]));
+        const cover = normalizeKugouCoverUrl(
+            findFieldDeep(response.data, ["union_cover", "album_img", "imgUrl", "imgurl", "img", "cover"])
+        );
+
+        return {
+            url,
+            size,
+            cover,
+            audioType: url ? (url.split("?")[0].split(".").pop() || "mp3") : "mp3",
+            quality: qualityItem,
+            qualityLabel: getKugouQualityLabel(qualityItem),
+            cookie: response.cookie,
+            requestHash,
+            error: findFieldDeep(response.data, ["error", "msg", "message"]),
+        };
+    }
 
     return {
-        url,
-        size,
-        cover,
-        audioType: url ? (url.split("?")[0].split(".").pop() || "mp3") : "mp3",
-        cookie: response.cookie,
-        raw: response.data,
-        error: findFieldDeep(response.data, ["error", "msg", "message"]),
+        url: "",
+        size: "",
+        cover: "",
+        audioType: "mp3",
+        quality: normalizeKugouQuality(quality),
+        qualityLabel: getKugouQualityLabel(normalizeKugouQuality(quality)),
+        cookie: requestCookie,
+        raw: null,
+        error: errors.join("；"),
     };
 }
 
@@ -535,11 +617,17 @@ export async function getKugouSongInfoByHash(hash, albumId = "", albumAudioId = 
 
     const data = response.data || {};
     const extra = data.extra || {};
+    const qualityHashes = {
+        128: extra["128hash"] || data.hash || hash,
+        320: extra["320hash"],
+        sq: extra["sqhash"],
+        high: extra["highhash"],
+    };
     const alternativeHashes = [
-        extra["128hash"],
-        extra["320hash"],
-        extra["sqhash"],
-        extra["highhash"],
+        qualityHashes[128],
+        qualityHashes[320],
+        qualityHashes.sq,
+        qualityHashes.high,
     ].filter(Boolean);
 
     return {
@@ -550,6 +638,7 @@ export async function getKugouSongInfoByHash(hash, albumId = "", albumAudioId = 
         albumId: String(data.albumid || data.req_albumid || albumId || "").trim(),
         albumAudioId: String(data.album_audio_id || albumAudioId || "").trim(),
         cover: normalizeKugouCoverUrl(data.trans_param?.union_cover || data.album_img || data.imgUrl || ""),
+        qualityHashes,
         alternativeHashes: Array.from(new Set(alternativeHashes.map(item => String(item).trim()).filter(Boolean))),
         raw: data,
     };
@@ -722,7 +811,7 @@ export async function resolveKugouRedirect(url) {
     }
 }
 
-export async function resolveKugouMusicSource(apiServer, { message = "", kugouCookie = "" } = {}) {
+export async function resolveKugouMusicSource(apiServer, { message = "", kugouCookie = "", quality = "" } = {}) {
     const warnings = [];
     const kugouInfo = await parseKugouMusicInfo(message);
     let musicInfo = kugouInfo?.audioName || [kugouInfo?.authorName, kugouInfo?.songName].filter(Boolean).join(" - ");
@@ -737,6 +826,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
     let albumId = kugouInfo?.albumId || "";
     let albumAudioId = kugouInfo?.albumAudioId || "";
     let officialSongInfo = null;
+    let qualityLabel = "";
 
     if (hash) {
         try {
@@ -745,9 +835,12 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
                 albumId,
                 albumAudioId,
                 cookie: kugouCookie,
+                quality,
             });
             url = urlResult.url || "";
+            hash = urlResult.requestHash || hash;
             audioType = urlResult.audioType || audioType;
+            qualityLabel = urlResult.qualityLabel || qualityLabel;
             size = urlResult.size || size;
             cover = urlResult.cover || cover;
             songName = songName || urlResult.raw?.fileName || "";
@@ -786,7 +879,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
                 cookie: kugouCookie,
             });
         }
-        const candidateResult = await tryKugouSongCandidates(apiServer, officialCandidates, kugouCookie);
+        const candidateResult = await tryKugouSongCandidates(apiServer, officialCandidates, kugouCookie, quality);
         warnings.push(...candidateResult.warnings);
         if (candidateResult.resolvedSong) {
             const { candidate, urlResult } = candidateResult.resolvedSong;
@@ -798,6 +891,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
             cover = urlResult.cover || candidate.cover || cover;
             url = urlResult.url || "";
             audioType = urlResult.audioType || audioType;
+            qualityLabel = urlResult.qualityLabel || qualityLabel;
             size = urlResult.size || size;
             musicInfo = candidate.audioName || createKugouFileName(songName, singerName, hash);
         }
@@ -831,7 +925,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
                     cookie: searchResult.cookie || kugouCookie,
                 });
             }
-            const candidateResult = await tryKugouSongCandidates(apiServer, candidateList, searchResult.cookie || kugouCookie);
+            const candidateResult = await tryKugouSongCandidates(apiServer, candidateList, searchResult.cookie || kugouCookie, quality);
             warnings.push(...candidateResult.warnings);
             if (candidateResult.resolvedSong) {
                 const { candidate, urlResult } = candidateResult.resolvedSong;
@@ -854,6 +948,7 @@ export async function resolveKugouMusicSource(apiServer, { message = "", kugouCo
         musicInfo,
         url,
         audioType,
+        qualityLabel,
         cover,
         size,
         singerName,


### PR DESCRIPTION
新增酷狗解析音质选项，适配了锅巴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kugou “解析音质” setting with selectable quality modes (e.g., Hi-Res/FLAC/320K/128K).
  * Kugou playback now requests and returns quality-aware audio options, improving result labeling/details.

* **Bug Fixes**
  * Improved Kugou audio resolution by trying quality fallbacks when the requested quality isn’t available.
  * Enhanced result metadata so displayed size/label reflects the resolved quality when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->