### PR TITLE
🐞fix: 修复元宝链接总结缺少 x-uskey 导致服务繁忙

### DIFF
--- a/guoba.support.js
+++ b/guoba.support.js
@@ -722,7 +722,7 @@ export function supportGuoba() {
                     bottomHelpMessage:
                         "链接总结方式选择：\n" +
                         "• 通用模式（默认）：浏览器抓取页面正文或内容 + 自配 AI（kimi/openai）总结，依赖 aiApiKey 配置\n" +
-                        "• 元宝模式：直接把链接发给腾讯元宝抓取并总结，与视频号共用上面的元宝 Cookie，可规避部分页面风控（环境异常），但元宝对话接口有 IP 风控（部署服务器 IP 需与元宝登录 IP 一致）",
+                        "• 元宝模式：直接把链接发给腾讯元宝抓取并总结，与视频号共用上面的元宝 Cookie；需要 Playwright Chromium（用于生成 x-uskey 签名头），且部署服务器 IP 需尽量与元宝登录 IP 一致",
                     component: "Select",
                     componentProps: {
                         options: LINK_SUMMARY_RESOLVE_MODE_LIST,

--- a/utils/weixin-article-yuanbao.js
+++ b/utils/weixin-article-yuanbao.js
@@ -73,6 +73,8 @@ const YUANBAO_CHAT_PAGE = `https://yuanbao.tencent.com/chat/${AGENT_ID}`;
  *   Cookie 变化时自动重建
  */
 let uskeySession = null;
+// 串行化 uskey 会话创建 + page.evaluate，避免并发总结互相关掉对方页面
+let uskeyGenerationQueue = Promise.resolve();
 
 function buildSummaryPrompt(input, { isContent = false } = {}) {
     const sourceLabel = isContent ? '网页内容' : '链接';
@@ -192,11 +194,10 @@ async function getPlaywrightBrowser() {
 }
 
 /**
- * 关闭 uskey 会话（仅关闭我们创建的 context/page；独立 browser 也一并关闭）
+ * 关闭指定 uskey 会话资源（可传会话对象，避免并发时误清全局指针）
+ * @param {object|null} [session]
  */
-async function closeUskeySession() {
-    const session = uskeySession;
-    uskeySession = null;
+async function disposeUskeySession(session) {
     if (!session) return;
     try {
         await session.page?.close().catch(() => {});
@@ -213,7 +214,17 @@ async function closeUskeySession() {
 }
 
 /**
+ * 关闭当前全局 uskey 会话
+ */
+async function closeUskeySession() {
+    const session = uskeySession;
+    uskeySession = null;
+    await disposeUskeySession(session);
+}
+
+/**
  * 确保存在可用的元宝页面，用于调用前端 Qimei SDK 生成 x-uskey
+ * 注意：调用方需保证串行（见 generateSecurityHeaders 队列），本函数本身不处理并发互斥
  * @param {string} cookie
  * @returns {Promise<{ page: import('playwright').Page }>}
  */
@@ -237,74 +248,74 @@ async function ensureUskeySession(cookie) {
         throw new Error('获取到的浏览器对象不是原生 Playwright Browser（缺少 newContext）');
     }
 
-    // 独立 context，避免污染宿主默认 context 的 Cookie/UA
-    const context = await browser.newContext({
-        userAgent: COMMON_HEADERS['user-agent'],
-        viewport: { width: 1280, height: 800 },
-        locale: 'zh-CN',
-    });
-    const ownedContext = true;
-    await context.addCookies(parseCookieString(cookie));
-    const page = await context.newPage();
+    let context;
+    let page;
+    try {
+        // 独立 context，避免污染宿主默认 context 的 Cookie/UA
+        context = await browser.newContext({
+            userAgent: COMMON_HEADERS['user-agent'],
+            viewport: { width: 1280, height: 800 },
+            locale: 'zh-CN',
+        });
+        await context.addCookies(parseCookieString(cookie));
+        page = await context.newPage();
 
-    // 打开元宝对话页，等待 webpack + Qimei SDK 就绪
-    await page.goto(YUANBAO_CHAT_PAGE, {
-        waitUntil: 'domcontentloaded',
-        timeout: 60000,
-    });
+        // 打开元宝对话页，等待 webpack + Qimei SDK 就绪
+        await page.goto(YUANBAO_CHAT_PAGE, {
+            waitUntil: 'domcontentloaded',
+            timeout: 60000,
+        });
 
-    // 轮询等待 getUSKeySync 可用（通常 1-3 秒）
-    const ready = await page.waitForFunction(() => {
-        try {
-            let webpackRequire = null;
-            if (!self.webpackChunk_N_E) return false;
-            self.webpackChunk_N_E.push([[`__yb_uskey_ready_${Date.now()}__`], {}, (req) => {
-                webpackRequire = req;
-            }]);
-            if (!webpackRequire) return false;
-            const mod = webpackRequire(12601);
-            const inst = mod?.I5?.('0WEB05U9OEC1ZNRY');
-            const h38 = inst?.getLocalQimei36?.()?.h38 || localStorage.getItem('_qimei_h38') || '';
-            return !!(inst?.getUSKeySync && h38 && String(h38).length === 38);
-        } catch (_) {
-            return false;
+        // 轮询等待 getUSKeySync 可用（通常 1-3 秒）
+        const ready = await page.waitForFunction(() => {
+            try {
+                let webpackRequire = null;
+                if (!self.webpackChunk_N_E) return false;
+                self.webpackChunk_N_E.push([[`__yb_uskey_ready_${Date.now()}__`], {}, (req) => {
+                    webpackRequire = req;
+                }]);
+                if (!webpackRequire) return false;
+                const mod = webpackRequire(12601);
+                const inst = mod?.I5?.('0WEB05U9OEC1ZNRY');
+                const h38 = inst?.getLocalQimei36?.()?.h38 || localStorage.getItem('_qimei_h38') || '';
+                return !!(inst?.getUSKeySync && h38 && String(h38).length === 38);
+            } catch (_) {
+                return false;
+            }
+        }, { timeout: 30000 }).then(() => true).catch(() => false);
+
+        if (!ready) {
+            throw new Error('元宝页面 Qimei SDK 初始化超时，无法生成 x-uskey（可检查 Cookie 是否失效或网络是否可达 yuanbao.tencent.com）');
         }
-    }, { timeout: 30000 }).then(() => true).catch(() => false);
 
-    if (!ready) {
-        await context.close().catch(() => {});
-        if (owned) await browser.close().catch(() => {});
-        throw new Error('元宝页面 Qimei SDK 初始化超时，无法生成 x-uskey（可检查 Cookie 是否失效或网络是否可达 yuanbao.tencent.com）');
+        uskeySession = {
+            browser,
+            owned,
+            context,
+            ownedContext: true,
+            page,
+            cookie,
+        };
+        logger.info('[R插件][链接总结][元宝] x-uskey 生成会话已就绪');
+        return uskeySession;
+    } catch (err) {
+        // 初始化任一步失败都回收已创建资源，避免 context/browser 泄漏
+        await page?.close().catch(() => {});
+        await context?.close().catch(() => {});
+        // 仅关闭我们独立 launch 的 browser；宿主 browser 绝不能关
+        if (owned) {
+            await browser.close().catch(() => {});
+        }
+        throw err;
     }
-
-    uskeySession = { browser, owned, context, ownedContext, page, cookie };
-    // 独立 browser 在进程退出时尽量回收，避免 bot 热重载后残留 chromium
-    if (owned && !globalThis.__rpluginYuanbaoUskeyExitHooked) {
-        const cleanup = () => { closeUskeySession(); };
-        process.once('exit', cleanup);
-        process.once('SIGINT', cleanup);
-        process.once('SIGTERM', cleanup);
-        globalThis.__rpluginYuanbaoUskeyExitHooked = true;
-    }
-    logger.info('[R插件][链接总结][元宝] x-uskey 生成会话已就绪');
-    return uskeySession;
 }
 
 /**
- * 生成元宝业务签名头：
- *   x-uskey / x-bus-params-md5 / x-timestamp
- *
- * 前端逻辑（_app.js 抓包还原）：
- *   h38 = qimei.getLocalQimei36().h38
- *   params = `h38=${h38}&timestamp=${Date.now()}&platform=web`
- *   x-uskey = encodeURIComponent(qimei.getUSKeySync("7800385", h38, params))
- *   x-bus-params-md5 = md5(params)
- *   x-timestamp = timestamp
- *
+ * 实际生成元宝业务签名头（需在串行队列中调用）
  * @param {string} cookie
  * @returns {Promise<object>}
  */
-async function generateSecurityHeaders(cookie) {
+async function generateSecurityHeadersUnsafe(cookie) {
     const session = await ensureUskeySession(cookie);
     const deviceId = getCookieValue(cookie, '_qimei_uuid42');
 
@@ -345,6 +356,33 @@ async function generateSecurityHeaders(cookie) {
 }
 
 /**
+ * 生成元宝业务签名头：
+ *   x-uskey / x-bus-params-md5 / x-timestamp
+ *
+ * 前端逻辑（_app.js 抓包还原）：
+ *   h38 = qimei.getLocalQimei36().h38
+ *   params = `h38=${h38}&timestamp=${Date.now()}&platform=web`
+ *   x-uskey = encodeURIComponent(qimei.getUSKeySync("7800385", h38, params))
+ *   x-bus-params-md5 = md5(params)
+ *   x-timestamp = timestamp
+ *
+ * 并发保护：
+ *   多个总结请求可能同时进入；uskeySession 是全局共享页面，
+ *   必须串行化“确保会话 + evaluate”，否则会互相 close 对方 page。
+ *
+ * @param {string} cookie
+ * @returns {Promise<object>}
+ */
+async function generateSecurityHeaders(cookie) {
+    const run = uskeyGenerationQueue.then(
+        () => generateSecurityHeadersUnsafe(cookie),
+    );
+    // 前一个失败也不阻塞后续任务
+    uskeyGenerationQueue = run.catch(() => undefined);
+    return run;
+}
+
+/**
  * 构建带 Cookie + referer 的完整请求头
  * @param {string} cookie 腾讯元宝 Web 端 Cookie
  * @param {string} chatId 会话 ID（用于 referer 与 x-agentid）
@@ -356,11 +394,12 @@ async function generateSecurityHeaders(cookie) {
  * @returns {object}
  */
 function buildHeaders(cookie, chatId, extra = {}, { chatIdInPath = true } = {}) {
-    const path = chatIdInPath ? `${AGENT_ID}/${chatId}` : AGENT_ID;
+    // chatId 为空时强制只使用 agentId，避免生成 naQivTmsDa/ 这种尾斜杠路径
+    const path = (chatIdInPath && chatId) ? `${AGENT_ID}/${chatId}` : AGENT_ID;
     return {
         ...COMMON_HEADERS,
         'referer': `https://yuanbao.tencent.com/chat/${path}`,
-        'x-agentid': chatIdInPath ? path : AGENT_ID,
+        'x-agentid': path,
         'cookie': cookie,
         ...extra,
     };
@@ -379,7 +418,8 @@ export async function createConversation(cookie) {
         YUANBAO_CONVERSATION_CREATE,
         { agentId: AGENT_ID },
         {
-            headers: buildHeaders(cookie, '', securityHeaders),
+            // create 时尚无 chatId，referer/x-agentid 只带 agentId，避免 naQivTmsDa/ 尾斜杠
+            headers: buildHeaders(cookie, '', securityHeaders, { chatIdInPath: false }),
             timeout: 15000,
         },
     );

--- a/utils/weixin-article-yuanbao.js
+++ b/utils/weixin-article-yuanbao.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import crypto from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
 import {
     YUANBAO_CHAT,
@@ -22,19 +23,22 @@ import { SUMMARY_PROMPT } from '../constants/constant.js';
  *   3. POST /api/chat/{chatId} 发送"总结：<文章URL>"消息，接收 SSE 流拼接元宝返回内容
  *   4. POST /api/user/agent/conversation/v1/clear 删除会话（无论成功失败都清理）
  *
- * 鉴权：仅需腾讯元宝 Web 端 Cookie，不需要微信登录。
+ * 鉴权：
+ *   - Cookie：腾讯元宝 Web 端登录态
+ *   - x-uskey / x-bus-params-md5 / x-timestamp：元宝 Web 前端 Qimei SDK 生成的业务签名头
+ *     （2026-07 起 /api/chat 强校验；缺失时会返回“服务繁忙，请稍后再试。”）
+ *
  * payload 格式参考：https://github.com/chenwr727/yuanbao-free-api
  */
 
 // 元宝 Web 端公共请求头（设备指纹部分，与视频号 PARSE_HEADERS 保持一致风格）
-// 注意：t-userid / x-device-id 等指纹头与 Cookie 不强绑定，沙箱实测用任意值均能调通会话管理接口
 const COMMON_HEADERS = {
     'accept': 'application/json, text/plain, */*',
     'accept-language': 'zh-CN,zh-TW;q=0.9,zh;q=0.8',
     'content-type': 'application/json',
     'origin': 'https://yuanbao.tencent.com',
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36',
-    'sec-ch-ua': `"Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"`,
+    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
+    'sec-ch-ua': `"Chromium";v="134", "Not:A-Brand";v="24", "Google Chrome";v="134"`,
     'sec-ch-ua-mobile': '?0',
     'sec-ch-ua-platform': `"Windows"`,
     'sec-fetch-dest': 'empty',
@@ -43,16 +47,32 @@ const COMMON_HEADERS = {
     'x-language': 'zh-CN',
     'x-platform': 'win',
     'x-source': 'web',
-    'x-webversion': '2.74.1',
+    'x-webversion': '2.76.3',
     'x-requested-with': 'XMLHttpRequest',
     'x-webdriver': '0',
     'x-ybuitest': '0',
+    'x-instance-id': '5',
+    'x-os_version': 'Windows(10)-Blink',
+    'x-web-third-source': 'main',
 };
 
 // 元宝默认智能体 ID（与视频号解析 referer 里的一致）
 const AGENT_ID = 'naQivTmsDa';
 // 默认对话模型（混元 175B，元宝网页版默认模型）
 const DEFAULT_MODEL = 'hunyuan_gpt_175B_0404';
+// 元宝前端 Qimei / Beacon appKey（抓包确认，用于 getUSKeySync）
+const QIMEI_APP_KEY = '0WEB05U9OEC1ZNRY';
+// 元宝前端 getUSKeySync 的固定业务 appId
+const USKEY_APP_ID = '7800385';
+// 元宝对话页，用于初始化 Qimei SDK
+const YUANBAO_CHAT_PAGE = `https://yuanbao.tencent.com/chat/${AGENT_ID}`;
+
+/**
+ * uskey 生成会话缓存：
+ *   复用同一个 Playwright context/page，避免每次总结都重新打开元宝首页（约 2-5 秒）
+ *   Cookie 变化时自动重建
+ */
+let uskeySession = null;
 
 function buildSummaryPrompt(input, { isContent = false } = {}) {
     const sourceLabel = isContent ? '网页内容' : '链接';
@@ -61,6 +81,267 @@ function buildSummaryPrompt(input, { isContent = false } = {}) {
 请严格遵循以上角色、规则与输出格式要求，直接总结下面提供的${sourceLabel}，不要输出额外寒暄，也不要重复提示词内容。
 
 ${sourceLabel}：${input}`;
+}
+
+/**
+ * 从 Cookie 字符串提取指定字段
+ * @param {string} cookie
+ * @param {string} name
+ * @returns {string}
+ */
+function getCookieValue(cookie, name) {
+    if (!cookie) return '';
+    const match = cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+    return match ? match[1] : '';
+}
+
+/**
+ * 把 Cookie 字符串转成 Playwright cookies
+ * @param {string} cookie
+ * @returns {Array<object>}
+ */
+function parseCookieString(cookie) {
+    return String(cookie || '')
+        .split(';')
+        .map(part => part.trim())
+        .filter(Boolean)
+        .map(pair => {
+            const idx = pair.indexOf('=');
+            if (idx <= 0) return null;
+            return {
+                name: pair.slice(0, idx).trim(),
+                value: pair.slice(idx + 1),
+                domain: '.yuanbao.tencent.com',
+                path: '/',
+            };
+        })
+        .filter(Boolean);
+}
+
+/**
+ * 判断是否是原生 Playwright Browser（有 newContext）
+ * 宿主 puppeteer.js 返回的是 PuppeteerCompatBrowser，只有 newPage，没有 newContext
+ * @param {any} browser
+ * @returns {boolean}
+ */
+function isNativePlaywrightBrowser(browser) {
+    return !!(browser && typeof browser.newContext === 'function');
+}
+
+/**
+ * 从宿主 bot 解包真正的 Playwright Browser
+ * 兼容路径：
+ *   1. renderer.manager.browser（原生 Playwright）
+ *   2. puppeteer.browser.browser（PuppeteerCompatBrowser 内部原生实例）
+ *   3. puppeteer.browser（仅当它本身就有 newContext）
+ * @returns {Promise<import('playwright').Browser|null>}
+ */
+async function getHostPlaywrightBrowser() {
+    try {
+        const puppeteer = (await import('../../../lib/puppeteer/puppeteer.js')).default;
+        if (typeof puppeteer?.browserInit === 'function') {
+            await puppeteer.browserInit();
+        }
+
+        // 优先拿渲染器底层 manager 的原生 browser
+        const managerBrowser = puppeteer?.manager?.browser;
+        if (isNativePlaywrightBrowser(managerBrowser)) {
+            return managerBrowser;
+        }
+
+        // 其次从兼容层包装对象上解包
+        const compat = puppeteer?.browser;
+        if (isNativePlaywrightBrowser(compat)) {
+            return compat;
+        }
+        if (isNativePlaywrightBrowser(compat?.browser)) {
+            return compat.browser;
+        }
+    } catch (err) {
+        logger.debug(`[R插件][链接总结][元宝] 复用宿主浏览器失败: ${err.message}`);
+    }
+    return null;
+}
+
+/**
+ * 获取可用的 Playwright Chromium
+ * 优先复用宿主 bot 已启动的原生 Playwright 浏览器，失败时再独立 launch
+ * @returns {Promise<{ browser: import('playwright').Browser, owned: boolean }>}
+ */
+async function getPlaywrightBrowser() {
+    // 1) 宿主 bot 原生 Playwright browser
+    const hostBrowser = await getHostPlaywrightBrowser();
+    if (hostBrowser) {
+        return { browser: hostBrowser, owned: false };
+    }
+
+    // 2) 插件/工作区独立 Playwright
+    try {
+        const { chromium } = await import('playwright');
+        const browser = await chromium.launch({
+            headless: true,
+            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+        });
+        return { browser, owned: true };
+    } catch (err) {
+        throw new Error(
+            `无法启动 Playwright 浏览器以生成元宝 x-uskey：${err.message}。` +
+            `请确认宿主已安装 Chromium（bun run browser:install）`,
+        );
+    }
+}
+
+/**
+ * 关闭 uskey 会话（仅关闭我们创建的 context/page；独立 browser 也一并关闭）
+ */
+async function closeUskeySession() {
+    const session = uskeySession;
+    uskeySession = null;
+    if (!session) return;
+    try {
+        await session.page?.close().catch(() => {});
+        // 只关闭我们自己 new 出来的 context；不要动宿主默认 context
+        if (session.ownedContext && session.context) {
+            await session.context.close().catch(() => {});
+        }
+        if (session.owned && session.browser) {
+            await session.browser.close().catch(() => {});
+        }
+    } catch (_) {
+        // ignore
+    }
+}
+
+/**
+ * 确保存在可用的元宝页面，用于调用前端 Qimei SDK 生成 x-uskey
+ * @param {string} cookie
+ * @returns {Promise<{ page: import('playwright').Page }>}
+ */
+async function ensureUskeySession(cookie) {
+    if (uskeySession?.page && uskeySession.cookie === cookie) {
+        // 页面可能被外部关闭，做一次轻量探活
+        try {
+            if (!uskeySession.page.isClosed()) {
+                return uskeySession;
+            }
+        } catch (_) {
+            // fallthrough recreate
+        }
+        await closeUskeySession();
+    } else if (uskeySession) {
+        await closeUskeySession();
+    }
+
+    const { browser, owned } = await getPlaywrightBrowser();
+    if (!isNativePlaywrightBrowser(browser)) {
+        throw new Error('获取到的浏览器对象不是原生 Playwright Browser（缺少 newContext）');
+    }
+
+    // 独立 context，避免污染宿主默认 context 的 Cookie/UA
+    const context = await browser.newContext({
+        userAgent: COMMON_HEADERS['user-agent'],
+        viewport: { width: 1280, height: 800 },
+        locale: 'zh-CN',
+    });
+    const ownedContext = true;
+    await context.addCookies(parseCookieString(cookie));
+    const page = await context.newPage();
+
+    // 打开元宝对话页，等待 webpack + Qimei SDK 就绪
+    await page.goto(YUANBAO_CHAT_PAGE, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60000,
+    });
+
+    // 轮询等待 getUSKeySync 可用（通常 1-3 秒）
+    const ready = await page.waitForFunction(() => {
+        try {
+            let webpackRequire = null;
+            if (!self.webpackChunk_N_E) return false;
+            self.webpackChunk_N_E.push([[`__yb_uskey_ready_${Date.now()}__`], {}, (req) => {
+                webpackRequire = req;
+            }]);
+            if (!webpackRequire) return false;
+            const mod = webpackRequire(12601);
+            const inst = mod?.I5?.('0WEB05U9OEC1ZNRY');
+            const h38 = inst?.getLocalQimei36?.()?.h38 || localStorage.getItem('_qimei_h38') || '';
+            return !!(inst?.getUSKeySync && h38 && String(h38).length === 38);
+        } catch (_) {
+            return false;
+        }
+    }, { timeout: 30000 }).then(() => true).catch(() => false);
+
+    if (!ready) {
+        await context.close().catch(() => {});
+        if (owned) await browser.close().catch(() => {});
+        throw new Error('元宝页面 Qimei SDK 初始化超时，无法生成 x-uskey（可检查 Cookie 是否失效或网络是否可达 yuanbao.tencent.com）');
+    }
+
+    uskeySession = { browser, owned, context, ownedContext, page, cookie };
+    // 独立 browser 在进程退出时尽量回收，避免 bot 热重载后残留 chromium
+    if (owned && !globalThis.__rpluginYuanbaoUskeyExitHooked) {
+        const cleanup = () => { closeUskeySession(); };
+        process.once('exit', cleanup);
+        process.once('SIGINT', cleanup);
+        process.once('SIGTERM', cleanup);
+        globalThis.__rpluginYuanbaoUskeyExitHooked = true;
+    }
+    logger.info('[R插件][链接总结][元宝] x-uskey 生成会话已就绪');
+    return uskeySession;
+}
+
+/**
+ * 生成元宝业务签名头：
+ *   x-uskey / x-bus-params-md5 / x-timestamp
+ *
+ * 前端逻辑（_app.js 抓包还原）：
+ *   h38 = qimei.getLocalQimei36().h38
+ *   params = `h38=${h38}&timestamp=${Date.now()}&platform=web`
+ *   x-uskey = encodeURIComponent(qimei.getUSKeySync("7800385", h38, params))
+ *   x-bus-params-md5 = md5(params)
+ *   x-timestamp = timestamp
+ *
+ * @param {string} cookie
+ * @returns {Promise<object>}
+ */
+async function generateSecurityHeaders(cookie) {
+    const session = await ensureUskeySession(cookie);
+    const deviceId = getCookieValue(cookie, '_qimei_uuid42');
+
+    const raw = await session.page.evaluate(({ appKey, appId }) => {
+        let webpackRequire = null;
+        self.webpackChunk_N_E.push([[`__yb_uskey_gen_${Date.now()}__`], {}, (req) => {
+            webpackRequire = req;
+        }]);
+        if (!webpackRequire) {
+            throw new Error('webpackRequire unavailable');
+        }
+        const mod = webpackRequire(12601);
+        const inst = mod.I5(appKey);
+        const h38 = inst?.getLocalQimei36?.()?.h38 || localStorage.getItem('_qimei_h38') || '';
+        if (!h38 || String(h38).length !== 38) {
+            throw new Error(`invalid h38: ${h38}`);
+        }
+        const ts = Date.now();
+        const params = `h38=${h38}&timestamp=${ts}&platform=web`;
+        const uskey = inst.getUSKeySync(appId, h38, params);
+        if (!uskey) {
+            throw new Error('empty uskey');
+        }
+        return { h38, ts, params, uskey };
+    }, { appKey: QIMEI_APP_KEY, appId: USKEY_APP_ID });
+
+    const busMd5 = crypto.createHash('md5').update(raw.params).digest('hex');
+    return {
+        'x-uskey': encodeURIComponent(raw.uskey),
+        'x-bus-params-md5': busMd5,
+        'x-timestamp': String(raw.ts),
+        // 设备指纹：优先 Cookie 中的 _qimei_uuid42
+        ...(deviceId ? {
+            'x-device-id': deviceId,
+            'x-hy93': deviceId,
+        } : {}),
+    };
 }
 
 /**
@@ -79,7 +360,7 @@ function buildHeaders(cookie, chatId, extra = {}, { chatIdInPath = true } = {}) 
     return {
         ...COMMON_HEADERS,
         'referer': `https://yuanbao.tencent.com/chat/${path}`,
-        'x-agentid': path,
+        'x-agentid': chatIdInPath ? path : AGENT_ID,
         'cookie': cookie,
         ...extra,
     };
@@ -91,12 +372,14 @@ function buildHeaders(cookie, chatId, extra = {}, { chatIdInPath = true } = {}) 
  * @returns {Promise<string>} chatId 会话 ID
  */
 export async function createConversation(cookie) {
+    // create 接口同样在前端 uskey 签名白名单内，需带签名头
+    const securityHeaders = await generateSecurityHeaders(cookie);
     // payload 必须带 agentId，实测抓包确认；不带 agentId 也能创建但建议与网页版一致
     const resp = await axios.post(
         YUANBAO_CONVERSATION_CREATE,
         { agentId: AGENT_ID },
         {
-            headers: buildHeaders(cookie, ''),
+            headers: buildHeaders(cookie, '', securityHeaders),
             timeout: 15000,
         },
     );
@@ -126,8 +409,10 @@ export async function initConversationModel(cookie, chatId) {
             internetSearch: 'autoInternetSearch',
         }),
     };
+    // updateModel 不在 uskey 白名单，但补签名头无副作用
+    const securityHeaders = await generateSecurityHeaders(cookie).catch(() => ({}));
     await axios.post(YUANBAO_CONVERSATION_UPDATE_MODEL, payload, {
-        headers: buildHeaders(cookie, chatId),
+        headers: buildHeaders(cookie, chatId, securityHeaders),
         timeout: 15000,
     });
     logger.info(`[R插件][链接总结][元宝] 初始化模型成功: ${DEFAULT_MODEL}`);
@@ -182,6 +467,18 @@ function parseSSEStream(stream, { onChunk } = {}) {
         let buffer = '';
         // 使用流式 UTF-8 解码器，避免 chunk 边界切断多字节中文字符导致乱码或 JSON 解析失败
         const decoder = new StringDecoder('utf8');
+        let settled = false;
+
+        const settleReject = (err) => {
+            if (settled) return;
+            settled = true;
+            reject(err);
+        };
+        const settleResolve = (val) => {
+            if (settled) return;
+            settled = true;
+            resolve(val);
+        };
 
         const handleLine = (line) => {
             line = line.trim();
@@ -215,7 +512,16 @@ function parseSSEStream(stream, { onChunk } = {}) {
 
             // 错误事件
             if (obj.type === 'error' || (obj.error && obj.error.code && String(obj.error.code) !== '0')) {
-                reject(new Error(`元宝接口错误: ${obj.error?.message || obj.msg || obj.error?.code}`));
+                const msg = obj.error?.message || obj.msg || obj.error?.code || 'unknown';
+                // 把“服务繁忙”映射成更可操作的提示（多数是缺 x-uskey 或 Cookie/IP 风控）
+                if (String(msg).includes('服务繁忙')) {
+                    settleReject(new Error(
+                        '元宝接口错误: 服务繁忙，请稍后再试。' +
+                        '（常见原因：x-uskey 签名失败 / Cookie 失效 / 部署 IP 与登录 IP 不一致）',
+                    ));
+                    return;
+                }
+                settleReject(new Error(`元宝接口错误: ${msg}`));
                 return;
             }
 
@@ -241,22 +547,23 @@ function parseSSEStream(stream, { onChunk } = {}) {
             buffer += decoder.end();
             // 处理 buffer 中剩余内容
             if (buffer.trim()) handleLine(buffer);
+            if (settled) return;
             const fullText = parts.join('').trim();
             if (!fullText) {
-                reject(new Error('元宝接口未返回任何文本内容，可能是接口格式变动或 Cookie 失效'));
+                settleReject(new Error('元宝接口未返回任何文本内容，可能是接口格式变动或 Cookie 失效'));
                 return;
             }
-            resolve(fullText);
+            settleResolve(fullText);
         });
 
-        stream.on('error', (err) => reject(err));
+        stream.on('error', (err) => settleReject(err));
     });
 }
 
 /**
  * Step 3: 发送链接总结请求并接收 SSE 流
  *
- * payload 与 headers 格式来自元宝网页版实测抓包（2026-06），
+ * payload 与 headers 格式来自元宝网页版实测抓包（2026-06 / 2026-07），
  * 与 yuanbao-free-api 早期版本有差异，以实际抓包为准。
  *
  * 关键字段：
@@ -269,6 +576,7 @@ function parseSSEStream(stream, { onChunk } = {}) {
  *   - content-type: text/plain;charset=UTF-8（非 application/json）
  *   - chat_version: v1
  *   - referer / x-agentid 不带 chatId（仅 naQivTmsDa）
+ *   - x-uskey / x-bus-params-md5 / x-timestamp：对话接口强校验（缺则返回服务繁忙）
  *
  * @param {string} cookie 腾讯元宝 Web 端 Cookie
  * @param {string} chatId 会话 ID
@@ -319,12 +627,18 @@ export async function chatSummarize(cookie, chatId, input, options = {}) {
         offsetOfMinute: 0,
     };
 
+    // 每次对话都重新生成签名头（timestamp 绑定 uskey，不可复用）
+    const securityHeaders = await generateSecurityHeaders(cookie);
+
     const resp = await axios.post(`${YUANBAO_CHAT}${chatId}`, body, {
         // chat 接口 referer/x-agentid 不带 chatId（实测抓包确认）
         headers: buildHeaders(cookie, chatId, {
             accept: '*/*',
             'content-type': 'text/plain;charset=UTF-8',
             'chat_version': 'v1',
+            'x-input-type': 'text',
+            'x-event-input-type': '11',
+            ...securityHeaders,
         }, { chatIdInPath: false }),
         timeout,
         responseType: 'stream',
@@ -387,6 +701,10 @@ export async function summarizeLink(url, cookie, options = {}) {
         if (status === 401) {
             throw new Error('元宝对话接口返回 401 未授权，可能是 Cookie 失效或部署服务器 IP 与元宝登录 IP 不一致（元宝对话接口有 IP 风控）');
         }
+        // uskey 会话异常时下次重建
+        if (/x-uskey|Qimei|Playwright|webpackRequire|h38/i.test(err.message || '')) {
+            await closeUskeySession();
+        }
         throw err;
     } finally {
         // Step 4: 无论成败都清理会话
@@ -429,6 +747,9 @@ export async function summarizeContent(content, cookie, options = {}) {
         const status = err?.response?.status;
         if (status === 401) {
             throw new Error('元宝对话接口返回 401 未授权，可能是 Cookie 失效或部署服务器 IP 与元宝登录 IP 不一致（元宝对话接口有 IP 风控）');
+        }
+        if (/x-uskey|Qimei|Playwright|webpackRequire|h38/i.test(err.message || '')) {
+            await closeUskeySession();
         }
         throw err;
     } finally {


### PR DESCRIPTION
## Summary
- 修复元宝模式链接总结在 `/api/chat` 阶段返回“服务繁忙，请稍后再试。”并自动回退通用模式的问题
- 根因是元宝 Web 端现已强制校验 `x-uskey` / `x-bus-params-md5` / `x-timestamp`，原先仅带 Cookie 不够
- 通过 Playwright 打开元宝页，调用前端 Qimei SDK 动态生成签名头；兼容宿主 `PuppeteerCompatBrowser`，解包原生 Playwright Browser 后再 `newContext`

## Changes
- `utils/weixin-article-yuanbao.js`
  - 新增 x-uskey 生成会话（复用 Playwright page，避免每次冷启动）
  - create / chat 请求补齐签名头与设备指纹头
  - 兼容宿主 bot 的浏览器封装（`manager.browser` / `compat.browser`）
- `guoba.support.js`
  - 更新元宝模式说明：依赖 Playwright Chromium 生成 x-uskey

## Test plan
- [x] 本地复现：不带 `x-uskey` 时 SSE 立即返回“服务繁忙”
- [x] 本地复现：补上 `x-uskey` 后可正常总结微信文章
- [x] 修复后端到端：`summarizeLink(mp.weixin.qq.com/...)` 成功返回总结文本
- [x] 验证宿主兼容层解包：`PuppeteerCompatBrowser` 无 `newContext`，能正确取到原生 Playwright Browser
- [ ] 线上重启 bot 后发送微信文章链接，确认元宝模式不再回退通用模式

## Notes
- `x-uskey` 与 timestamp 绑定，不能长期写死，需运行时生成
- 需要宿主已安装 Playwright Chromium（通常已有；缺失时执行 `bun run browser:install`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Yuanbao chat summarization by regenerating security signing per request to strengthen device verification.

* **Bug Fixes**
  * Enhanced streaming handling to better detect “service busy” cases and prevent silent incomplete results.
  * Added more reliable recovery by automatically closing the secure signing session after signing/automation-related failures, so the next attempt can rebuild.

* **Documentation**
  * Updated “链接总结模式” (元宝模式) help text with clearer requirements for Chromium-based signing and guidance to keep server IP consistent with the login IP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->