### PR TITLE
✨feat: 元宝链接总结支持切换 DeepSeek V3

### DIFF
--- a/apps/tools.js
+++ b/apps/tools.js
@@ -488,6 +488,8 @@ export class tools extends plugin {
         this.weixinChannelYuanbaoCookie = this.toolsConfig.weixinChannelYuanbaoCookie;
         // 加载链接总结解析模式：general-通用（默认），yuanbao-元宝
         this.linkSummaryResolveMode = this.toolsConfig.linkSummaryResolveMode || 'general';
+        // 元宝模式可选模型：hunyuan_gpt_175B_0404 / deep_seek_v3
+        this.linkSummaryYuanbaoModel = this.toolsConfig.linkSummaryYuanbaoModel || 'hunyuan_gpt_175B_0404';
     }
 
     // 翻译插件
@@ -4230,21 +4232,27 @@ export class tools extends plugin {
 
         try {
             const isWeixinArticle = /mp\.weixin\.qq\.com/i.test(summaryLink);
+            // 运行时读取模型，避免构造时缓存导致锅巴切换不生效
+            const yuanbaoModel = toolsConfig.linkSummaryYuanbaoModel
+                || this.linkSummaryYuanbaoModel
+                || 'hunyuan_gpt_175B_0404';
+            const yuanbaoOptions = {
+                timeout: 120000,
+                model: yuanbaoModel,
+            };
+            logger.info(`[R插件][链接总结][元宝模式] 使用模型: ${yuanbaoModel}`);
             const summary = isWeixinArticle
-                ? await summarizeLinkByYuanbao(summaryLink, cookie, {
-                    timeout: 120000,
-                })
-                : await summarizeContentByYuanbao(await llmRead(summaryLink), cookie, {
-                    timeout: 120000,
-                });
+                ? await summarizeLinkByYuanbao(summaryLink, cookie, yuanbaoOptions)
+                : await summarizeContentByYuanbao(await llmRead(summaryLink), cookie, yuanbaoOptions);
 
             // 元宝返回的总结文本可能较长，使用合并转发发送
             // 头部标注「腾讯元宝」解析方式，让用户清楚是哪种模式产出的
             const stats = estimateReadingTime(summary);
             const titleMatch = summary.match(/(Title|标题)([:：])\s*(.*?)\n/)?.[3] || summary.match(/(Title|标题)([:：])\s*(.*)/)?.[3];
             e.reply(`《${titleMatch || '未知标题'}》 预计阅读时间: ${stats.minutes} 分钟，总字数: ${stats.words}`);
+            const modelLabel = yuanbaoModel === 'deep_seek_v3' ? 'DeepSeek V3' : '混元 175B';
             const Msg = await Bot.makeForwardMsg(textArrayToMakeForward(e, [
-                `「R插件 x 腾讯元宝」联合为您总结内容：`,
+                `「R插件 x 腾讯元宝（${modelLabel}）」联合为您总结内容：`,
                 summary,
             ]));
             await replyWithRetry(e, Bot, Msg);

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -78,6 +78,7 @@ weiboComments: true # 是否显示微博评论，默认开启
 weixinChannelYuanbaoCookie: '' # 视频号解析所需腾讯元宝Cookie，浏览器登录 https://yuanbao.tencent.com 后 F12→Network→任意请求→Request Headers→Cookie 复制；也可私聊机器人发送 #设置视频号Cookie 进行设置，参考：https://github.com/ltaoo/wx_channels_download
 
 linkSummaryResolveMode: 'general' # 链接总结模式：general-通用模式（浏览器抓取正文/页面内容 + 自配AI总结，默认），yuanbao-元宝模式（直接发给腾讯元宝抓取总结，与视频号共用元宝Cookie，规避部分风控，但元宝对话接口有IP风控需部署服务器IP与元宝登录IP一致）
+linkSummaryYuanbaoModel: 'hunyuan_gpt_175B_0404' # 元宝总结模型（仅元宝模式生效）：hunyuan_gpt_175B_0404-混元175B（默认），deep_seek_v3-DeepSeek V3
 
 xiaoheiheCookie: '' # 小黑盒Cookie，格式：x_xhh_tokenid=xxx
 

--- a/constants/constant.js
+++ b/constants/constant.js
@@ -300,6 +300,15 @@ export const LINK_SUMMARY_RESOLVE_MODE_LIST = Object.freeze([
     { label: '通用模式', value: 'general' },
     { label: '元宝模式', value: 'yuanbao' },
 ]);
+
+/**
+ * 元宝链接总结可选模型（chatModelId）
+ * 值对齐 yuanbao.tencent.com 网页端实测字段
+ */
+export const LINK_SUMMARY_YUANBAO_MODEL_LIST = Object.freeze([
+    { label: '混元 175B（默认）', value: 'hunyuan_gpt_175B_0404' },
+    { label: 'DeepSeek V3', value: 'deep_seek_v3' },
+]);
 /**
  * 消息撤回时间
  * @type {number}

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import path from "path";
-import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, KUGOU_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST, LINK_SUMMARY_RESOLVE_MODE_LIST } from "./constants/constant.js";
+import { BILI_CDN_SELECT_LIST, BILI_DEFAULT_CDN_LIST, BILI_DOWNLOAD_METHOD, BILI_RESOLUTION_LIST, VIDEO_CODEC_LIST, YOUTUBE_GRAPHICS_LIST, NETEASECLOUD_QUALITY_LIST, KUGOU_QUALITY_LIST, DOUYIN_BGM_SEND_TYPE, DOUYIN_COMMENT_COUNT_LIST, DOUYIN_COMMENT_CHUNK_SIZE_LIST, BILI_COMMENT_COUNT_LIST, BILI_COMMENT_CHUNK_SIZE_LIST, LINK_SUMMARY_RESOLVE_MODE_LIST, LINK_SUMMARY_YUANBAO_MODEL_LIST } from "./constants/constant.js";
 import { RESOLVE_CONTROLLER_NAME_ENUM } from "./constants/resolve.js";
 import model from "./model/config.js";
 
@@ -726,6 +726,18 @@ export function supportGuoba() {
                     component: "Select",
                     componentProps: {
                         options: LINK_SUMMARY_RESOLVE_MODE_LIST,
+                    },
+                },
+                {
+                    field: "tools.linkSummaryYuanbaoModel",
+                    label: "元宝总结模型",
+                    bottomHelpMessage:
+                        "仅在「链接总结模式=元宝模式」时生效：\n" +
+                        "• 混元 175B（默认）：hunyuan_gpt_175B_0404，元宝网页默认模型\n" +
+                        "• DeepSeek V3：deep_seek_v3，对应网页端切换 DeepSeek 时的 chatModelId",
+                    component: "Select",
+                    componentProps: {
+                        options: LINK_SUMMARY_YUANBAO_MODEL_LIST,
                     },
                 },
                 {

--- a/utils/weixin-article-yuanbao.js
+++ b/utils/weixin-article-yuanbao.js
@@ -19,7 +19,7 @@ import { SUMMARY_PROMPT } from '../constants/constant.js';
  *
  * 解析流程（一次性会话）：
  *   1. POST /api/user/agent/conversation/create 新建会话 → 拿 chatId
- *   2. POST /api/user/agent/conversation/updateModel 初始化模型为 hunyuan_gpt_175B_0404
+ *   2. POST /api/user/agent/conversation/updateModel 初始化模型（默认 hunyuan_gpt_175B_0404，可选 deep_seek_v3）
  *   3. POST /api/chat/{chatId} 发送"总结：<文章URL>"消息，接收 SSE 流拼接元宝返回内容
  *   4. POST /api/user/agent/conversation/v1/clear 删除会话（无论成功失败都清理）
  *
@@ -60,6 +60,13 @@ const COMMON_HEADERS = {
 const AGENT_ID = 'naQivTmsDa';
 // 默认对话模型（混元 175B，元宝网页版默认模型）
 const DEFAULT_MODEL = 'hunyuan_gpt_175B_0404';
+// 支持的 chatModelId（对齐网页端）
+const SUPPORTED_MODELS = new Set([
+    'hunyuan_gpt_175B_0404',
+    'deep_seek_v3',
+]);
+// chat 接口里的 model 字段与 chatModelId 不同：混元仍用 gpt_175B_0404，DeepSeek 抓包也继续传 gpt_175B_0404
+const CHAT_API_MODEL = 'gpt_175B_0404';
 // 元宝前端 Qimei / Beacon appKey（抓包确认，用于 getUSKeySync）
 const QIMEI_APP_KEY = '0WEB05U9OEC1ZNRY';
 // 元宝前端 getUSKeySync 的固定业务 appId
@@ -83,6 +90,25 @@ function buildSummaryPrompt(input, { isContent = false } = {}) {
 请严格遵循以上角色、规则与输出格式要求，直接总结下面提供的${sourceLabel}，不要输出额外寒暄，也不要重复提示词内容。
 
 ${sourceLabel}：${input}`;
+}
+
+/**
+ * 归一化元宝模型 ID
+ * @param {string} [model]
+ * @returns {string}
+ */
+function resolveYuanbaoModel(model) {
+    const id = String(model || DEFAULT_MODEL).trim();
+    if (SUPPORTED_MODELS.has(id)) return id;
+    // 兼容简写
+    if (/^deepseek/i.test(id) || id === 'deep_seek' || id === 'ds' || id === 'deepseek_v3') {
+        return 'deep_seek_v3';
+    }
+    if (/hunyuan|混元/i.test(id)) {
+        return DEFAULT_MODEL;
+    }
+    logger.warn(`[R插件][链接总结][元宝] 未知模型 ${id}，回退到 ${DEFAULT_MODEL}`);
+    return DEFAULT_MODEL;
 }
 
 /**
@@ -432,18 +458,20 @@ export async function createConversation(cookie) {
 }
 
 /**
- * Step 2: 初始化会话模型（混元 175B + 自动联网搜索）
+ * Step 2: 初始化会话模型（支持混元 175B / DeepSeek V3）
  * 不调用此步骤直接发消息有时会返回空，沙箱实测必须先初始化模型
  * @param {string} cookie 腾讯元宝 Web 端 Cookie
  * @param {string} chatId 会话 ID
+ * @param {string} [model=DEFAULT_MODEL] chatModelId，如 deep_seek_v3
  */
-export async function initConversationModel(cookie, chatId) {
+export async function initConversationModel(cookie, chatId, model = DEFAULT_MODEL) {
+    const chatModelId = resolveYuanbaoModel(model);
     const payload = {
         cid: chatId,
-        chatModelId: DEFAULT_MODEL,
+        chatModelId,
         // chatModelExtInfo 是嵌套 JSON 字符串（元宝网页版原样格式）
         chatModelExtInfo: JSON.stringify({
-            modelId: DEFAULT_MODEL,
+            modelId: chatModelId,
             subModelId: '',
             supportFunctions: { internetSearch: 'autoInternetSearch' },
             internetSearch: 'autoInternetSearch',
@@ -455,7 +483,7 @@ export async function initConversationModel(cookie, chatId) {
         headers: buildHeaders(cookie, chatId, securityHeaders),
         timeout: 15000,
     });
-    logger.info(`[R插件][链接总结][元宝] 初始化模型成功: ${DEFAULT_MODEL}`);
+    logger.info(`[R插件][链接总结][元宝] 初始化模型成功: ${chatModelId}`);
 }
 
 /**
@@ -628,12 +656,14 @@ function parseSSEStream(stream, { onChunk } = {}) {
  * @returns {Promise<string>} 元宝总结的完整文本
  */
 export async function chatSummarize(cookie, chatId, input, options = {}) {
-    const { timeout = 120000, onChunk, isContent = false } = options;
+    const { timeout = 120000, onChunk, isContent = false, model = DEFAULT_MODEL } = options;
+    const chatModelId = resolveYuanbaoModel(model);
 
     const prompt = buildSummaryPrompt(input, { isContent });
     // payload 字段对齐元宝网页版实测抓包格式
+    // 注意：body.model 固定 gpt_175B_0404；真正切换模型靠 chatModelId / chatModelExtInfo.modelId
     const body = {
-        model: 'gpt_175B_0404',
+        model: CHAT_API_MODEL,
         prompt,
         plugin: '',
         displayPrompt: prompt,
@@ -641,7 +671,7 @@ export async function chatSummarize(cookie, chatId, input, options = {}) {
         agentId: AGENT_ID,
         isTemporary: false,
         projectId: '',
-        chatModelId: DEFAULT_MODEL,
+        chatModelId,
         supportFunctions: ['openAutoSearchSwitch', 'autoInternetSearch'],
         docOpenid: '',
         options: {
@@ -650,7 +680,7 @@ export async function chatSummarize(cookie, chatId, input, options = {}) {
         multimedia: [],
         supportHint: 1,
         chatModelExtInfo: JSON.stringify({
-            modelId: DEFAULT_MODEL,
+            modelId: chatModelId,
             subModelId: '',
             supportFunctions: { internetSearch: '' },
             internetSearch: 'autoInternetSearch',
@@ -727,12 +757,13 @@ export async function summarizeLink(url, cookie, options = {}) {
 
     let chatId = '';
     try {
+        const model = resolveYuanbaoModel(options.model);
         // Step 1: 新建会话
         chatId = await createConversation(cookie);
-        // Step 2: 初始化模型
-        await initConversationModel(cookie, chatId);
+        // Step 2: 初始化模型（混元 / DeepSeek 等）
+        await initConversationModel(cookie, chatId, model);
         // Step 3: 发送总结请求
-        const summary = await chatSummarize(cookie, chatId, normalizedUrl, options);
+        const summary = await chatSummarize(cookie, chatId, normalizedUrl, { ...options, model });
         logger.info(`[R插件][链接总结][元宝] 总结成功，文本长度: ${summary.length}`);
         return summary;
     } catch (err) {
@@ -775,11 +806,13 @@ export async function summarizeContent(content, cookie, options = {}) {
 
     let chatId = '';
     try {
+        const model = resolveYuanbaoModel(options.model);
         chatId = await createConversation(cookie);
-        await initConversationModel(cookie, chatId);
+        await initConversationModel(cookie, chatId, model);
         const summary = await chatSummarize(cookie, chatId, normalizedContent, {
             ...options,
             isContent: true,
+            model,
         });
         logger.info(`[R插件][链接总结][元宝] 内容总结成功，文本长度: ${summary.length}`);
         return summary;


### PR DESCRIPTION
## Summary
- 元宝模式下新增模型选择：混元 175B（默认）/ DeepSeek V3
- 新增配置项 `linkSummaryYuanbaoModel`，并同步锅巴「元宝总结模型」下拉
- 对齐网页端抓包：真正切换靠 `chatModelId` / `chatModelExtInfo.modelId`（如 `deep_seek_v3`），`body.model` 仍保持 `gpt_175B_0404`

## Changes
- `config/tools.yaml`：默认 `linkSummaryYuanbaoModel: hunyuan_gpt_175B_0404`
- `constants/constant.js`：`LINK_SUMMARY_YUANBAO_MODEL_LIST`
- `guoba.support.js`：元宝总结模型选项
- `apps/tools.js`：运行时读取模型并传给元宝 util，结果头部标注当前模型
- `utils/weixin-article-yuanbao.js`：`updateModel` 与 `/api/chat` 统一使用同一 `chatModelId`

## Test plan
- [x] `model: deep_seek_v3` 端到端总结微信文章成功
- [x] `node --check` 通过
- [ ] 锅巴切换到 DeepSeek V3 后发送链接，日志出现 `使用模型: deep_seek_v3` / `初始化模型成功: deep_seek_v3`
- [ ] 切回混元后默认行为不变

## Notes
- 仅在 `linkSummaryResolveMode: yuanbao` 时生效
- 这是管理员配置项，不是群友每条消息临时选模型